### PR TITLE
Feature/hmm export testset

### DIFF
--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -246,6 +246,8 @@ def configure_segment_motifs_parser(parser: argparse.ArgumentParser) -> None:
         "--num_iter", type=int, default=10, help="Number of iterations of EM"
     )
     parser.add_argument("--hmm_seed", type=int, help="RNG seed for HMM")
+    parser.add_argument("--save_hmm", type=Path, help="Path to save HMM model")
+    parser.add_argument("--test_data", type=Path, help="Test data for evaluation, it will not be used in the fitting process")
 
 
 def configure_select_prototypes_parser(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
In regard to the ISSUE #14.
Here is a proposition to solve it.
The solution take part in the "betman segment_motifs" feature : 
- A boolean to save the hmm model
- An input path for a testing dataset that will be used only in hmm.predict()