### PR TITLE
New HMM sampling feature

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## 🔜 Q2 2025
 - [ ] Add support for SLEAP ([#8, in progress](https://github.com/BelloneLab/lisbet/issues/8))
 - [ ] Add support for saving and loading HMMs ([#14, in progress](https://github.com/BelloneLab/lisbet/issues/14))
-- [ ] Speed up HMM fitting by training on a random subset of data ([#22](https://github.com/BelloneLab/lisbet/issues/22))
+- [x] Speed up HMM fitting by training on a random subset of data ([#22](https://github.com/BelloneLab/lisbet/issues/22))
 - [ ] Add native support for parallel HMM scanning in CLI ([#23](https://github.com/BelloneLab/lisbet/issues/23))
 - [ ] Implement and test fine-tuning of LISBET classifiers using HMM prototypes ([#24](https://github.com/BelloneLab/lisbet/issues/24))
 - [ ] Add support for n > 2 individuals, "multi-dyadic" strategy

--- a/docs/user_guide/behavior_discovery.rst
+++ b/docs/user_guide/behavior_discovery.rst
@@ -81,14 +81,22 @@ For example, your ``betman segment_motifs`` command might look something like th
       -v \
       bet_predictions/maDLC
 
+Currently, LISBET fits the HMM on the entire input dataset.
+For large datasets, this can lead to slow training times and high memory usage.
+
+To address this, you can fit the HMM on a random subset of the data, using the ``--fit_frac`` option (e.g., ``--fit_frac=0.1`` to use 10% of the data).
+After fitting, the trained model will still be used to transform and label the full dataset.
+In the current implementation, a simple random selection of full sequences is used.
+More advanced sampling strategies, such as windowed sampling or weighting by sequence length, could be considered in future iterations of LISBET if needed.
+
 Please use ``betman segment_motifs --help`` for a list of all available option.
 
-After running unsupman, you should find the annotations (i.e., labels) for your dataset in the OUTPUT_PATH directory.
+After running ``segment_motifs``, you should find the annotations (i.e., labels) for your dataset in the OUTPUT_PATH directory.
 
 As discussed in Chindemi et al. 2023, choosing the number of behaviors N_MOTIFS a priori is a limitation imposed by most clustering algorithms.
 If you want to avoid doing so, we propose a "scan-and-select" procedure which allows to specify an upper limit to the number of behaviors in your dataset, rather than the exact number, and automatically determine the actual number of behaviors in the dataset.
 This procedure is described below in **Step 3: Prototype selection**.
-Before proceeding with Step 3, you need to generate multiple sets of HMM annotations by running unsupman, each time with a different N_MOTIFS, as described above.
+Before proceeding with Step 3, you need to generate multiple sets of HMM annotations by running ``segment_motifs``, each time with a different N_MOTIFS, as described above.
 In case you are using a SLURM cluster, this can be easily done by running ``betman segment_motifs`` in a JOB ARRAY.
 
 [OPTIONAL] Step 3: Prototype selection
@@ -111,7 +119,7 @@ To generate the embedding files for your dataset you can use **betman**:
 
 where ANNOT_PATH is the location of the LISBET annotations obtained in Step 2, MIN_STATES (MAX_STATES) is the smallest (largest) annotation set to consider (corresponding to the number of states in the HMM models), and METHOD determines how the prototype for a motif group is chosen (i.e., **best** will select the prototype with the highest silhouette coefficient).
 
-For example, your ``unsupman select_prototypes`` command might look something like this:
+For example, your ``betman select_prototypes`` command might look something like this:
 
 .. code-block:: console
 
@@ -124,7 +132,7 @@ For example, your ``unsupman select_prototypes`` command might look something li
 
 Please use ``betman select_prototypes --help`` for a list of all available option.
 
-After running unsupman, you should find the annotations (i.e., labels) for your dataset in the OUTPUT_PATH directory.
+After running ``select_prototypes``, you should find the annotations (i.e., labels) for your dataset in the OUTPUT_PATH directory.
 
 References
 ----------

--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -245,6 +245,9 @@ def configure_segment_motifs_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--num_iter", type=int, default=10, help="Number of iterations of EM"
     )
+    parser.add_argument(
+        "--fit_frac", type=float, help="Fraction of data to use for model fitting"
+    )
     parser.add_argument("--hmm_seed", type=int, help="RNG seed for HMM")
 
 

--- a/src/lisbet/unsupervised.py
+++ b/src/lisbet/unsupervised.py
@@ -77,7 +77,7 @@ def segment_hmm(
 
     # Random sample
     if fit_frac is not None:
-        assert 0 < fit_frac <= 1, "train_frac must be in the (0, 1] range"
+        assert 0 < fit_frac <= 1, "fit_frac must be in the (0, 1] range"
 
         rng = np.random.default_rng(seed=hmm_seed)
         indices = rng.choice(

--- a/src/lisbet/unsupervised.py
+++ b/src/lisbet/unsupervised.py
@@ -77,7 +77,7 @@ def segment_hmm(
 
     # Random sample
     if fit_frac is not None:
-        assert 0 < fit_frac <= 1, "train_frac must be between 0 and 1"
+        assert 0 < fit_frac <= 1, "train_frac must be in the (0, 1] range"
 
         rng = np.random.default_rng(seed=hmm_seed)
         indices = rng.choice(

--- a/src/lisbet/unsupervised.py
+++ b/src/lisbet/unsupervised.py
@@ -67,6 +67,7 @@ def segment_hmm(
     num_states=4,
     num_iter=10,
     data_filter=None,
+    fit_frac=None,
     hmm_seed=None,
     output_path=None,
 ):
@@ -74,9 +75,22 @@ def segment_hmm(
     # Get LISBET embeddings for the dataset
     embeddings = _get_embeddings(data_path, data_filter)
 
+    # Random sample
+    if fit_frac is not None:
+        assert 0 < fit_frac <= 1, "train_frac must be between 0 and 1"
+
+        rng = np.random.default_rng(seed=hmm_seed)
+        indices = rng.choice(
+            len(embeddings), size=int(np.ceil(fit_frac * len(embeddings)))
+        )
+        fit_embeddings = [embeddings[idx] for idx in indices]
+        logging.info("Sampled %d sequences for model fitting", len(fit_embeddings))
+    else:
+        fit_embeddings = embeddings
+
     # Merge sequences
-    lengths = [emb[1].shape[0] for emb in embeddings]
-    all_embeddings = np.concatenate([emb[1] for emb in embeddings])
+    fit_lengths = [emb[1].shape[0] for emb in fit_embeddings]
+    fit_embeddings = np.concatenate([emb[1] for emb in fit_embeddings])
 
     # # NEW!!! Smoothing
     # all_embeddings = median_filter(all_embeddings, size=(30, 1), origin=(-15, 0))
@@ -90,12 +104,12 @@ def segment_hmm(
         tol=1e-3,
         verbose=False,
     )
-    hmm_model.fit(all_embeddings, lengths=lengths)
+    hmm_model.fit(fit_embeddings, lengths=fit_lengths)
     hmm_history = list(hmm_model.monitor_.history)
     hmm_metrics = {
-        "ll": hmm_model.score(all_embeddings, lengths=lengths),
-        "aic": hmm_model.aic(all_embeddings, lengths=lengths),
-        "bic": float(hmm_model.bic(all_embeddings, lengths=lengths)),
+        "ll": hmm_model.score(fit_embeddings, lengths=fit_lengths),
+        "aic": hmm_model.aic(fit_embeddings, lengths=fit_lengths),
+        "bic": float(hmm_model.bic(fit_embeddings, lengths=fit_lengths)),
     }
 
     # Store fitting results on file, if requested
@@ -114,15 +128,17 @@ def segment_hmm(
             yaml.safe_dump(hmm_metrics, f_yaml)
 
     # HMM predictions
-    all_predictions = hmm_model.predict(all_embeddings, lengths=lengths)
+    all_lengths = [emb[1].shape[0] for emb in embeddings]
+    all_embeddings = np.concatenate([emb[1] for emb in embeddings])
+    all_predictions = hmm_model.predict(all_embeddings, lengths=all_lengths)
 
     # Assign predictions to match the corresponding sequences
     predictions = []
     for seq_idx, (key, seq) in enumerate(embeddings):
         # Find prediction boundaries for the current sequence
-        seq_start = sum(lengths[:seq_idx])
-        seq_stop = seq_start + lengths[seq_idx]
-        assert seq.shape[0] == lengths[seq_idx]
+        seq_start = sum(all_lengths[:seq_idx])
+        seq_stop = seq_start + all_lengths[seq_idx]
+        assert seq.shape[0] == all_lengths[seq_idx]
         logging.debug("Sequence start = %d, Sequence stop = %d", seq_start, seq_stop)
 
         # Extract prediction


### PR DESCRIPTION
This pull request introduces a new feature to allow fitting Hidden Markov Models (HMMs) on a random subset of data, improving performance for large datasets. It also includes related documentation updates and minor refactoring. Below are the most important changes grouped by theme:

### New Feature: Subset Fitting for HMMs
* Added a `--fit_frac` option to the CLI command `segment_motifs` to specify the fraction of data to use for model fitting. This allows users to train HMMs on a random subset of the dataset, reducing memory usage and training time.

### Documentation Updates
* Updated the user guide to describe the new `--fit_frac` option, its usage, and its benefits for large datasets. Clarified command examples and corrected outdated references to `unsupman`, replacing them with `betman`.

### Roadmap Update
* Marked the task "Speed up HMM fitting by training on a random subset of data" as completed in the `ROADMAP.md` file.