### PR TITLE
Select prototypes revision v2

### DIFF
--- a/docs/user_guide/behavior_discovery.rst
+++ b/docs/user_guide/behavior_discovery.rst
@@ -127,11 +127,11 @@ To generate the embedding files for your dataset you can use **betman**:
 .. code-block:: console
 
    $ betman select_prototypes \
-      --hmm_range LOW HIGH \       # Smallest and largest annotation set to consider
-      --output_path=OUTPUT_PATH \  # Path to store annotation files (i.e., labels)
-      --method=METHOD \            # Prototype selection method
-      -v \                         # Enable verbose mode
-      ANNOT_PATH                   # Path to the root of the annotation sets
+      --min_n_components=MIN_STATES \  # Smallest HMM annotation set to consider
+      --max_n_components=MAX_STATES \  # Largest HMM annotation set to consider
+      --method=METHOD \                # Prototype selection method
+      -v \                             # Enable verbose mode
+      ANNOT_PATH                       # Path to the root of the annotation sets
 
 where ANNOT_PATH is the location of the LISBET annotations obtained in Step 2, MIN_STATES (MAX_STATES) is the smallest (largest) annotation set to consider (corresponding to the number of states in the HMM models), and METHOD determines how the prototype for a motif group is chosen (i.e., **best** will select the prototype with the highest silhouette coefficient).
 
@@ -140,11 +140,11 @@ For example, your ``betman select_prototypes`` command might look something like
 .. code-block:: console
 
    $ betman select_prototypes \
-      --hmm_range 6 32 \
-      --output_path=proto_predictions \
+      --min_n_components=6 \
+      --max_n_components=32 \
       --method=best \
       -v \
-      hmm_predictions/maDLC
+      annotations
 
 Please use ``betman select_prototypes --help`` for a list of all available option.
 

--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -240,8 +240,18 @@ def configure_segment_motifs_parser(parser: argparse.ArgumentParser) -> None:
     """Configure segment_motifs command parser."""
     add_verbosity_args(parser)
     add_data_io_args(parser, "Embedding data location")
-    parser.add_argument("--min_n_components", type=int, default=2, help="Minimum number of hidden states")
-    parser.add_argument("--max_n_components", type=int, default=32, help="Maximum number of hidden states")
+    parser.add_argument(
+        "--min_n_components",
+        type=int,
+        default=2,
+        help="Minimum number of hidden states",
+    )
+    parser.add_argument(
+        "--max_n_components",
+        type=int,
+        default=32,
+        help="Maximum number of hidden states",
+    )
     parser.add_argument(
         "--num_iter", type=int, default=10, help="Number of iterations of EM"
     )
@@ -262,40 +272,47 @@ def configure_select_prototypes_parser(parser: argparse.ArgumentParser) -> None:
     """Configure select_prototypes command parser."""
     add_verbosity_args(parser)
     add_data_io_args(parser, "Annotation data location")
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument(
-        "--hmm_range",
+    parser.add_argument(
+        "--min_n_components",
         type=int,
-        nargs=2,
-        metavar=("LOW", "HIGH"),
-        help="Range of HMM sizes",
+        default=6,
+        help="Minimum number of hidden states",
     )
-    group.add_argument(
-        "--hmm_list", type=int, nargs="+", metavar="HMM_SIZE", help="List of HMM sizes"
+    parser.add_argument(
+        "--max_n_components",
+        type=int,
+        default=32,
+        help="Maximum number of hidden states",
     )
     parser.add_argument(
         "--method",
-        default="min",
+        default="best",
         choices=["min", "best"],
         help="Prototype selection algorithm",
     )
     parser.add_argument(
         "--frame_threshold",
         type=float,
+        default=0.05,
         help="Minimum fraction of allocated frames for motifs to be kept",
     )
     parser.add_argument(
         "--bout_threshold",
         type=float,
+        default=0.5,
         help="Minimum mean bout duration in seconds for motifs to be kept",
     )
     parser.add_argument(
         "--distance_threshold",
         type=float,
-        help="Maximum Jaccard distance from the closest motif (pairs only)",
+        default=0.6,
+        help="Maximum Jaccard distance from the closest neighbor motif",
     )
     parser.add_argument(
-        "--fps", type=float, help="Frames per second, used to compute bout duration"
+        "--fps",
+        type=float,
+        default=30,
+        help="Frames per second, used to compute bout duration",
     )
 
 

--- a/src/lisbet/postprocessing.py
+++ b/src/lisbet/postprocessing.py
@@ -176,19 +176,19 @@ def select_prototypes(
     ----------
     data_path : str
         The root directory containing the annotation files.
-    hmm_list : list of int, optional
-        A sorted list of unique Hidden Markov Model sizes. If `None`, `hmm_range` must be provided.
-    hmm_range : tuple of int, optional
-        A tuple specifying the range of Hidden Markov Model sizes (low, high). Used if `hmm_list` is `None`.
+    min_n_components : int, default=2
+        Minimum number of states for the HMMs.
+    max_n_components : int, default=32
+        Maximum number of states for the HMMs.
     method : str, default='best'
         Method for selecting prototypes. Valid options are 'min' and 'best'.
-    frame_threshold : float, optional
+    frame_threshold : float, default=0.05
         Minimum fraction of allocated frames for motifs to be kept.
-    bout_threshold : float, optional
+    bout_threshold : float, default=0.5
         Minimum mean bout duration in seconds for motifs to be kept.
-    distance_threshold : float, optional
+    distance_threshold : float, default=0.6
         Maximum Jaccard distance from the closest motif (pairs only).
-    fps : int, optional
+    fps : int, default=30
         Frames per second, used to compute bout duration.
     output_path : str, optional
         Path to store the output predictions. If `None`, results are not saved.

--- a/src/lisbet/postprocessing.py
+++ b/src/lisbet/postprocessing.py
@@ -160,13 +160,13 @@ def _filter_by_distance(concat_data, distance_threshold):
 
 def select_prototypes(
     data_path: str,
-    hmm_list: Optional[List[int]] = None,
-    hmm_range: Optional[Tuple[int, int]] = None,
+    min_n_components: int,
+    max_n_components: int,
     method: str = "best",
-    frame_threshold: Optional[float] = None,
-    bout_threshold: Optional[float] = None,
-    distance_threshold: Optional[float] = None,
-    fps: Optional[int] = None,
+    frame_threshold: float = 0.05,
+    bout_threshold: float = 0.5,
+    distance_threshold: float = 0.6,
+    fps: int = 30,
     output_path: Optional[str] = None,
 ) -> Tuple[Dict, List[Tuple[str, pd.DataFrame]]]:
     """
@@ -206,14 +206,8 @@ def select_prototypes(
     [a] This method could be easily generalized to other clustering algorithms.
 
     """
-    if hmm_list is None:
-        low, high = hmm_range
-        hmm_list = list(range(low, high + 1))
-
-    # List of states must be sorted
-    assert all(a < b for a, b in zip(hmm_list, hmm_list[1:]))
-
     # Load session data
+    hmm_list = list(range(min_n_components, max_n_components + 1))
     session_data = load_annotations(data_path, hmm_list)
 
     # Concatenate all sessions in a single dataset

--- a/src/lisbet/postprocessing.py
+++ b/src/lisbet/postprocessing.py
@@ -303,7 +303,7 @@ def select_prototypes(
 
         # Store predictions on file, if requested
         if output_path is not None:
-            dst_path = Path(output_path) / key
+            dst_path = Path(output_path) / "prototypes" / key
             dst_path.mkdir(parents=True, exist_ok=True)
 
             motifs.to_csv(


### PR DESCRIPTION
This pull request introduces changes to improve the usability and consistency of the `select_prototypes` functionality across the codebase and documentation. The primary updates include replacing `--hmm_range` and `--hmm_list` with `--min_n_components` and `--max_n_components` for specifying the range of HMM states, setting default values for several parameters, and updating related documentation.

### Changes to CLI Argument Parsing:
* Replaced `--hmm_range` and `--hmm_list` with `--min_n_components` and `--max_n_components` for specifying the range of HMM states, simplifying the interface (`src/lisbet/cli.py`).
* Added default values for `frame_threshold`, `bout_threshold`, `distance_threshold`, and `fps` to improve usability (`src/lisbet/cli.py`).

### Updates to Core Functionality:
* Modified the `select_prototypes` function to use `min_n_components` and `max_n_components` instead of `hmm_list` or `hmm_range`, and added default values for several parameters for consistency (`src/lisbet/postprocessing.py`).
* Changed the output directory structure for prototype predictions to include a "prototypes" subdirectory for better organization (`src/lisbet/postprocessing.py`).

### Documentation Updates:
* Updated the user guide to reflect the new CLI arguments (`--min_n_components` and `--max_n_components`) and provided an updated example command (`docs/user_guide/behavior_discovery.rst`).