### PR TITLE
Add model evaluation support

### DIFF
--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -452,6 +452,15 @@ def configure_model_info_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def configure_evaluate_model_parser(parser: argparse.ArgumentParser) -> None:
+    """Configure evaluate_model command parser."""
+    add_verbosity_args(parser)
+    add_keypoints_args(parser)
+    add_data_io_args(parser, "Keypoint data location")
+    parser.add_argument("model_path", type=Path, help="Path to model config")
+    parser.add_argument("weights_path", type=Path, help="Path to model weights")
+
+
 def main() -> None:
     """Main entry point for betman CLI."""
     parser = argparse.ArgumentParser(
@@ -538,6 +547,12 @@ def main() -> None:
             "module": ".modeling",
             "function": "model_info",
             "configure": configure_model_info_parser,
+        },
+        "evaluate_model": {
+            "description": "Evaluate a classification model on a labeled dataset",
+            "module": ".evaluation",
+            "function": "evaluate_model",
+            "configure": configure_evaluate_model_parser,
         },
     }
 

--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -459,6 +459,15 @@ def configure_evaluate_model_parser(parser: argparse.ArgumentParser) -> None:
     add_data_io_args(parser, "Keypoint data location")
     parser.add_argument("model_path", type=Path, help="Path to model config")
     parser.add_argument("weights_path", type=Path, help="Path to model weights")
+    parser.add_argument(
+        "--labels",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated list of integer labels to use for F1 score (e.g. "
+            "'0,1,2'). If not set, use all labels."
+        ),
+    )
 
 
 def main() -> None:

--- a/src/lisbet/evaluation.py
+++ b/src/lisbet/evaluation.py
@@ -109,13 +109,15 @@ def evaluate_model(
         rename_coords=rename_coords,
     )
 
+    # Convert to dict for easier access
+    group_records = dict(group_records["main_records"])
+
     # Flatten all records
     y_true = []
     y_pred = []
     for key, pred_arr in results:
         # Find corresponding record
-        rec = next(rec for rec in group_records["main_records"] if rec[0] == key)
-        true_labels = rec[1]["annotations"].label_cat.values
+        true_labels = group_records[key]["annotations"].label_cat.values
 
         # pred_arr is one-hot, take argmax
         pred_labels = np.argmax(pred_arr, axis=1)

--- a/src/lisbet/evaluation.py
+++ b/src/lisbet/evaluation.py
@@ -1,0 +1,82 @@
+"""Model evaluation utilities for LISBET.
+
+This module provides functions to evaluate classification models on labeled datasets.
+"""
+
+from typing import Optional
+
+import numpy as np
+from sklearn.metrics import classification_report, f1_score
+
+from . import inference
+from .datasets import load_records
+
+
+def evaluate_model(
+    model_path: str,
+    weights_path: str,
+    data_format: str,
+    data_path: str,
+    data_scale: Optional[str] = None,
+    data_filter: Optional[str] = None,
+    window_size: int = 200,
+    window_offset: int = 0,
+    fps_scaling: float = 1.0,
+    batch_size: int = 128,
+    select_coords: Optional[str] = None,
+    rename_coords: Optional[str] = None,
+):
+    """
+    Evaluate a classification model on a labeled dataset and print F1 score.
+
+    Parameters
+    ----------
+    (same as inference.annotate_behavior)
+    """
+    # Run inference to get predictions
+    results = inference._process_inference_dataset(
+        model_path=model_path,
+        weights_path=weights_path,
+        forward_fn=inference._classification_forward,
+        data_format=data_format,
+        data_path=data_path,
+        data_scale=data_scale,
+        window_size=window_size,
+        window_offset=window_offset,
+        fps_scaling=fps_scaling,
+        batch_size=batch_size,
+        data_filter=data_filter,
+        select_coords=select_coords,
+        rename_coords=rename_coords,
+    )
+
+    # Load ground-truth labels
+    group_records = load_records(
+        data_format,
+        data_path,
+        data_filter=data_filter,
+        data_scale=data_scale,
+        select_coords=select_coords,
+        rename_coords=rename_coords,
+    )
+
+    # Flatten all records
+    y_true = []
+    y_pred = []
+    for key, pred_arr in results:
+        # Find corresponding record
+        rec = next(rec for rec in group_records["main_records"] if rec[0] == key)
+        labels = rec[1]["annotations"].label_cat.values
+
+        # pred_arr is one-hot, take argmax
+        pred_labels = np.argmax(pred_arr, axis=1)
+
+        y_true.append(labels)
+        y_pred.append(pred_labels)
+
+    y_true = np.concatenate(y_true)
+    y_pred = np.concatenate(y_pred)
+
+    # 3. Compute and print F1 score
+    print("Macro F1 score:", f1_score(y_true, y_pred, average="macro"))
+    print(classification_report(y_true, y_pred, digits=3))

--- a/src/lisbet/evaluation.py
+++ b/src/lisbet/evaluation.py
@@ -56,6 +56,9 @@ def evaluate_model(
     )
 
     # Load ground-truth labels
+    # NOTE: We load the records twice, but at least we don't have to re-implement the
+    #       forward pass. In the future, we could consider decomposing the inference
+    #       function into smaller components to avoid this duplication.
     group_records = load_records(
         data_format,
         data_path,

--- a/src/lisbet/modeling.py
+++ b/src/lisbet/modeling.py
@@ -226,17 +226,19 @@ def export_embedder(model_path, weights_path, output_path=Path(".")):
     # Get hyper-parameters
     with open(model_path, encoding="utf-8") as f_yaml:
         yaml_config = yaml.safe_load(f_yaml)
+    model_id = yaml_config["model_id"] + "-embedder"
 
     # Create behavior embedding model
     # TODO: This should be improved.
     model_config = {
-        "input_features": yaml_config["input_features"],
+        "model_id": model_id,
         "bp_dim": yaml_config["bp_dim"],
         "emb_dim": yaml_config["emb_dim"],
         "hidden_dim": yaml_config["hidden_dim"],
         "num_heads": yaml_config["num_heads"],
         "num_layers": yaml_config["num_layers"],
         "max_len": yaml_config["max_len"],
+        "input_features": yaml_config["input_features"],
     }
     embedding_model = EmbeddingModel(
         output_token_idx=-1,
@@ -256,7 +258,7 @@ def export_embedder(model_path, weights_path, output_path=Path(".")):
     )
 
     # Create output directory
-    output_path = output_path / "models" / f"{model_path.parent.stem}-embedder"
+    output_path = output_path / "models" / model_id
 
     # Store configuration
     model_config["output_token_idx"] = -1

--- a/src/lisbet/training.py
+++ b/src/lisbet/training.py
@@ -637,6 +637,7 @@ def _save_model_config(
 ):
     """Internal helper. Saves model config."""
     model_config = {
+        "model_id": run_id,
         "window_size": window_size,
         "window_offset": window_offset,
         "output_token_idx": output_token_idx,


### PR DESCRIPTION
This pull request introduces a new feature to evaluate classification models on labeled datasets. It adds a CLI command, `evaluate_model`, and implements the corresponding functionality in a new module. The changes include updates to the CLI configuration and the addition of the evaluation logic.

### CLI Enhancements:
* Added a new CLI command, `evaluate_model`, to evaluate classification models. This includes a parser configuration to handle arguments such as model paths, weights, and optional labels.

### New Evaluation Module:
* Implemented the `evaluate_model` function in a new module, `src/lisbet/evaluation.py`. This function performs inference using the model, compares predictions with ground-truth labels, and computes metrics like the F1 score and classification report. It supports various data preprocessing options and user-specified label filtering.