### PR TITLE
Add support for mouse triplets and mabe22

### DIFF
--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -413,6 +413,7 @@ def configure_fetch_dataset_parser(parser: argparse.ArgumentParser) -> None:
         choices=(
             "CalMS21_Task1",
             "CalMS21_Unlabeled",
+            "MABe22_MouseTriplets",
             "SampleData",
         ),
         help="Dataset ID",

--- a/src/lisbet/cli.py
+++ b/src/lisbet/cli.py
@@ -200,7 +200,24 @@ def configure_train_model_parser(parser: argparse.ArgumentParser) -> None:
         "--task_ids",
         type=str,
         default="cfc",
-        help="Task ID or comma-separated list of task IDS.",
+        help=textwrap.dedent(
+            """\
+            Task ID or comma-separated list of task IDS.
+
+            Valid (supervised) tasks are:
+              - cfc: multi-Class Frame Classification
+              - lfc: multi-Label Frame Classification
+
+            Valid (self-supervised) tasks are:
+              - nwp: Next Window Prediction
+              - smp: Swap Mouse Prediction
+              - vsp: Video Speed Prediction
+              - dmp: Delay Mouse Prediction
+
+            Example:
+              nwp,smp
+            """
+        ),
     )
     parser.add_argument(
         "--task_data",

--- a/src/lisbet/datasets/calms21.py
+++ b/src/lisbet/datasets/calms21.py
@@ -37,6 +37,7 @@ def _preprocess_calms21(raw_data):
             fps=30,
             source_software="MARS",
         )
+        posetracks.attrs["image_size_px"] = [1024, 570]
 
         # Create record data structure
         rec_data = {"posetracks": posetracks}

--- a/src/lisbet/datasets/calms21.py
+++ b/src/lisbet/datasets/calms21.py
@@ -62,7 +62,7 @@ def _preprocess_calms21(raw_data):
             # Convert to xarray Dataset
             rec_data["annotations"] = xr.Dataset(
                 data_vars=dict(
-                    label=(
+                    target_cls=(
                         ["time", "behaviors", "annotators"],
                         one_hot_annotations[..., np.newaxis],
                     )

--- a/src/lisbet/datasets/core.py
+++ b/src/lisbet/datasets/core.py
@@ -13,7 +13,7 @@ from movement.transforms import scale
 from sklearn.model_selection import train_test_split
 from tqdm.auto import tqdm
 
-from . import calms21
+from . import calms21, mabe22
 
 
 def _load_posetracks(seq_path, data_format, data_scale, select_coords, rename_coords):
@@ -464,7 +464,10 @@ def fetch_dataset(dataset_id, download_path):
     if dataset_id == "CalMS21_Task1":
         # Get data from Caltech repo
         fnames = pooch.retrieve(
-            url="https://data.caltech.edu/records/s0vdx-0k302/files/task1_classic_classification.zip?download=1",
+            url=(
+                "https://data.caltech.edu/records/s0vdx-0k302/files/"
+                "task1_classic_classification.zip?download=1"
+            ),
             known_hash="md5:8a02654fddae28614ee24a6a082261b8",
             path=Path(download_path) / "datasets" / ".cache" / "lisbet",
             processor=pooch.Unzip(
@@ -493,7 +496,10 @@ def fetch_dataset(dataset_id, download_path):
     elif dataset_id == "CalMS21_Unlabeled":
         # Get data from Caltech repo
         fnames = pooch.retrieve(
-            url="https://data.caltech.edu/records/s0vdx-0k302/files/unlabeled_videos.zip?download=1",
+            url=(
+                "https://data.caltech.edu/records/s0vdx-0k302/files/"
+                "unlabeled_videos.zip?download=1"
+            ),
             known_hash="md5:35ab3acdeb231a3fe1536e38ad223b2e",
             path=Path(download_path) / "datasets" / ".cache" / "lisbet",
             processor=pooch.Unzip(
@@ -514,6 +520,46 @@ def fetch_dataset(dataset_id, download_path):
         # Store data in LISBET-compatible format
         data_path = Path(download_path) / "datasets" / "CalMS21" / "unlabeled_videos"
         dump_records(data_path, all_records)
+
+    elif dataset_id == "MABe22_MouseTriplets":
+        # Get data from Caltech repo
+        train_path = pooch.retrieve(
+            url=(
+                "https://data.caltech.edu/records/rdsa8-rde65/files/"
+                "mouse_triplet_train.npy?download=1"
+            ),
+            known_hash="md5:76a48f3a1679a219a0e7e8a87871cc74",
+            path=Path(download_path) / "datasets" / ".cache" / "lisbet",
+            progressbar=True,
+        )
+        test_seq_path = pooch.retrieve(
+            url=(
+                "https://data.caltech.edu/records/rdsa8-rde65/files/"
+                "mouse_triplet_test.npy?download=1"
+            ),
+            known_hash="md5:f43f0f8824ffe6a4496eaf3ba7559d5c",
+            path=Path(download_path) / "datasets" / ".cache" / "lisbet",
+            progressbar=True,
+        )
+        test_labels_path = pooch.retrieve(
+            url=(
+                "https://data.caltech.edu/records/rdsa8-rde65/files/"
+                "mouse_triplets_test_labels.npy?download=1"
+            ),
+            known_hash="md5:5a54f2d29a13a256aabbefc61a633176",
+            path=Path(download_path) / "datasets" / ".cache" / "lisbet",
+            progressbar=True,
+        )
+
+        # Preprocess keypoints
+        train_records, test_records = mabe22.load_mouse_triplets(
+            train_path, test_seq_path, test_labels_path
+        )
+
+        # Store records in LISBET-compatible format
+        data_path = Path(download_path) / "datasets" / "MABe22" / "mouse_triplets"
+        dump_records(data_path / "train", train_records)
+        dump_records(data_path / "test", test_records)
 
     elif dataset_id == "SampleData":
         # Fetch data from HuggingFace repo

--- a/src/lisbet/datasets/core.py
+++ b/src/lisbet/datasets/core.py
@@ -218,13 +218,13 @@ def _load_annotations(seq_path):
 
     logging.debug("Annotations: %s", annotations.coords["behaviors"].values)
 
-    # Convert annotations to label encoding format
-    # NOTE: This is a temporary solution to maintain compatibility with the current
-    #       implementation of training and inference pipelines.
-    # TODO: Add full support for one-hot and multi-label annotations
-    annotations = annotations.assign(
-        label_cat=annotations.label.argmax("behaviors").squeeze()
-    )
+    # # Convert annotations to label encoding format
+    # # NOTE: This is a temporary solution to maintain compatibility with the current
+    # #       implementation of training and inference pipelines.
+    # # TODO: Add full support for one-hot and multi-label annotations
+    # annotations = annotations.assign(
+    #     label_cat=annotations.label.argmax("behaviors").squeeze()
+    # )
 
     return annotations
 

--- a/src/lisbet/datasets/core.py
+++ b/src/lisbet/datasets/core.py
@@ -534,10 +534,11 @@ def fetch_dataset(dataset_id, download_path):
         )
         test_seq_path = pooch.retrieve(
             url=(
-                "https://data.caltech.edu/records/rdsa8-rde65/files/"
+                # TMP, bug in default Caltech repo
+                "https://data.caltech.edu/records/8kdn3-95j37/files/"
                 "mouse_triplet_test.npy?download=1"
             ),
-            known_hash="md5:f43f0f8824ffe6a4496eaf3ba7559d5c",
+            known_hash="md5:20dc132300118a64aac665dd68153b20",
             path=Path(download_path) / "datasets" / ".cache" / "lisbet",
             progressbar=True,
         )

--- a/src/lisbet/datasets/core.py
+++ b/src/lisbet/datasets/core.py
@@ -218,14 +218,6 @@ def _load_annotations(seq_path):
 
     logging.debug("Annotations: %s", annotations.coords["behaviors"].values)
 
-    # # Convert annotations to label encoding format
-    # # NOTE: This is a temporary solution to maintain compatibility with the current
-    # #       implementation of training and inference pipelines.
-    # # TODO: Add full support for one-hot and multi-label annotations
-    # annotations = annotations.assign(
-    #     label_cat=annotations.label.argmax("behaviors").squeeze()
-    # )
-
     return annotations
 
 

--- a/src/lisbet/datasets/mabe22.py
+++ b/src/lisbet/datasets/mabe22.py
@@ -1,0 +1,139 @@
+"""
+MABe22 dataset.
+
+References
+----------
+1. Sun, J. J. et al. MABe22: A Multi-Species Multi-Task Benchmark for Learned
+   Representations of Behavior. Preprint at https://doi.org/10.48550/arXiv.2207.10553
+   (2023).
+
+2. Sun, J. et al. Dataset for MABe22: A Multi-Species Multi-Task Benchmark for Learned
+   Representations of Behavior. CaltechDATA https://doi.org/10.22002/rdsa8-rde65 (2023).
+
+3. AIcrowd | MABe 2022: Mouse-Triplets - Video Data | Challenges. AIcrowd | MABe 2022:
+   Mouse-Triplets - Video Data | Challenges
+   https://www.aicrowd.com/challenges/multi-agent-behavior-challenge-2022/problems/mabe-2022-mouse-triplets-video-data.
+
+4. AIcrowd | MABe 2022: Mouse Triplets | Challenges. AIcrowd | MABe 2022: Mouse
+   Triplets | Challenges
+   https://www.aicrowd.com/challenges/multi-agent-behavior-challenge-2022/problems/mabe-2022-mouse-triplets.
+
+"""
+
+import logging
+
+import numpy as np
+from movement.io import load_poses
+from tqdm.auto import tqdm
+
+
+def _preprocess_mabe22_sequence(positions):
+    """Preprocess a sequence in the MABe22 Mouse Triplets datset."""
+    # Extract dims for convenience
+    n_frames, n_individuals, n_body_parts, n_space = positions.shape
+
+    # Invert coordinates and body parts dims
+    # NOTE: The original data is in the format (frames, individuals, body parts, space),
+    #       but we need to convert it to (frames, space, body parts, individuals) as
+    #       required by the movement library.
+    position_array = np.array(positions).transpose((0, 3, 2, 1))
+
+    # Missing confidence values
+    confidence_array = np.full(
+        (n_frames, n_body_parts, n_individuals), np.nan, dtype=float
+    )
+
+    # Convert to xarray Dataset
+    posetracks = load_poses.from_numpy(
+        position_array=position_array,
+        confidence_array=confidence_array,
+        individual_names=[f"mouse_{i}" for i in range(n_individuals)],
+        keypoint_names=[
+            "nose",
+            "left_ear",
+            "right_ear",
+            "neck",
+            "left_forepaw",
+            "right_forepaw",
+            "center_back",
+            "left_hindpaw",
+            "right_hindpaw",
+            "tail_base",
+            "tail_middle",
+            "tail_tip",
+        ],
+        fps=30,
+        source_software="HRnetKumarLab",
+    )
+    posetracks.attrs["image_size_px"] = [850, 850]
+
+    return posetracks
+
+
+def _load_train(train_path):
+    """Load the train data."""
+    # Load raw train data
+    train_raw = np.load(train_path, allow_pickle=True).item()
+
+    # Annotations vocabulary
+    # train_vocab = train_raw["vocabulary"]
+
+    # Load and preprocess train sequences
+    train_records = []
+    for rec_id, rec_seq in tqdm(
+        train_raw["sequences"].items(), desc="Processing train data"
+    ):
+        logging.debug("Processing %s data...", rec_id)
+
+        # Keypoints
+        posetracks = _preprocess_mabe22_sequence(rec_seq["keypoints"])
+
+        # Annotations
+        # TODO
+
+        # Create record data structure
+        rec_data = {"posetracks": posetracks}
+
+        train_records.append((rec_id, rec_data))
+
+    return train_records
+
+
+def _load_test(test_seq_path, test_labels_path):
+    """Load the test data."""
+    # Load raw test data
+    test_raw = np.load(test_seq_path, allow_pickle=True).item()
+
+    # Annotations vocabulary
+    # test_vocab = test_labels_path["vocabulary"]
+
+    # Load and preprocess test sequences
+    test_records = []
+    for rec_id, rec_seq in tqdm(
+        test_raw["sequences"].items(), desc="Processing test data"
+    ):
+        logging.debug("Processing %s data...", rec_id)
+
+        # Keypoints
+        posetracks = _preprocess_mabe22_sequence(rec_seq["keypoints"])
+
+        # Annotations
+        # TODO
+
+        # Create record data structure
+        rec_data = {"posetracks": posetracks}
+
+        test_records.append((rec_id, rec_data))
+
+    return test_records
+
+
+def load_mouse_triplets(train_path, test_seq_path, test_labels_path):
+    """"""
+    # Load and process train records
+    train_records = _load_train(train_path)
+
+    # Load and process test records
+    test_records = _load_test(test_seq_path, test_labels_path)
+
+    return train_records, test_records

--- a/src/lisbet/evaluation.py
+++ b/src/lisbet/evaluation.py
@@ -117,7 +117,12 @@ def evaluate_model(
     y_pred = []
     for key, pred_arr in results:
         # Find corresponding record
-        true_labels = group_records[key]["annotations"].label_cat.values
+        true_labels = (
+            group_records[key]["annotations"]
+            .target_cls.argmax("behaviors")
+            .squeeze()
+            .values
+        )
 
         # pred_arr is one-hot, take argmax
         pred_labels = np.argmax(pred_arr, axis=1)

--- a/src/lisbet/input_pipeline.py
+++ b/src/lisbet/input_pipeline.py
@@ -17,9 +17,9 @@ class BaseDataset(Dataset, ABC):
         # Extract individuals and their feature indices from the first record
         first_key = next(iter(self.records))
         features = self.records[first_key]["posetracks"].coords["features"].to_index()
-        self.individuals = features.get_level_values('individuals').unique().tolist()
+        self.individuals = features.get_level_values("individuals").unique().tolist()
         self.individual_feature_indices = {
-            ind: np.where(features.get_level_values('individuals') == ind)[0]
+            ind: np.where(features.get_level_values("individuals") == ind)[0]
             for ind in self.individuals
         }
 
@@ -146,7 +146,9 @@ class FrameClassificationDataset(BaseDataset):
         if self.num_classes is not None:
             y_data = (
                 self.records[curr_key]["annotations"]
-                .label_cat.isel(time=curr_loc)
+                .label.isel(time=curr_loc)
+                .argmax("behaviors")
+                .squeeze()
                 .values
             )
 

--- a/src/lisbet/input_pipeline.py
+++ b/src/lisbet/input_pipeline.py
@@ -507,9 +507,9 @@ class DelayMousePredictionDataset(BaseDataset):
         # Get shift data
         sft_data = self._select_and_pad(curr_key, sft_loc)
 
-        # Apply swapping: only swap the second individual's features
-        swap_idx = self.individual_feature_indices[self.individuals[1]]
-        curr_data[..., swap_idx] = sft_data[..., swap_idx]
+        # Apply shifting: only shift the second individual's features
+        sft_idx = self.individual_feature_indices[self.individuals[1]]
+        curr_data[..., sft_idx] = sft_data[..., sft_idx]
 
         if self.transform:
             curr_data = self.transform(curr_data)

--- a/src/lisbet/input_pipeline.py
+++ b/src/lisbet/input_pipeline.py
@@ -254,8 +254,8 @@ class SwapMousePredictionDataset(BaseDataset):
         swap_data = self._select_and_pad(swap_key, swap_loc)
 
         # Apply swapping: always swap the second individual's features
-        swap_idx = self.individual_feature_indices[self.individuals[1]]
-        curr_data[..., swap_idx] = swap_data[..., swap_idx]
+        feature_idx = self.individual_feature_indices[self.individuals[1]]
+        curr_data[..., feature_idx] = swap_data[..., feature_idx]
 
         if self.transform:
             curr_data = self.transform(curr_data)

--- a/src/lisbet/training.py
+++ b/src/lisbet/training.py
@@ -207,7 +207,7 @@ def _configure_classification_task(
     # Find number of behaviors in the training set
     labels = np.concatenate(
         [
-            data["annotations"].label.argmax("behaviors").squeeze().values
+            data["annotations"].target_cls.argmax("behaviors").squeeze().values
             for _, data in train_rec["cfc"]
         ]
     )

--- a/src/lisbet/training.py
+++ b/src/lisbet/training.py
@@ -383,6 +383,10 @@ def _configure_tasks(
                     data_format,
                 )
             )
+        elif task_id == "lfc":
+            raise NotImplementedError(
+                "Multi-Label Frame Classification task is not implemented yet."
+            )
         elif task_id in ("nwp", "smp", "vsp", "dmp"):
             tasks.append(
                 _configure_selfsupervised_task(

--- a/src/lisbet/training.py
+++ b/src/lisbet/training.py
@@ -206,7 +206,10 @@ def _configure_classification_task(
 
     # Find number of behaviors in the training set
     labels = np.concatenate(
-        [data["annotations"].label_cat for _, data in train_rec["cfc"]]
+        [
+            data["annotations"].label.argmax("behaviors").squeeze().values
+            for _, data in train_rec["cfc"]
+        ]
     )
     classes = np.unique(labels)
     num_classes = len(classes)

--- a/src/lisbet/training.py
+++ b/src/lisbet/training.py
@@ -484,7 +484,7 @@ def _configure_optimizer_and_scheduler(model, learning_rate, mixed_precision):
     return optimizer, scheduler, scaler
 
 
-def _configure_dataloaders(tasks, group, batch_size, group_sample):
+def _configure_dataloaders(tasks, group, batch_size, group_sample, pin_memory):
     """Internal helper. Configures dataloaders for a group."""
     # Estimate number of samples
     num_samples = min(len(task["datasets"][group]) for task in tasks)
@@ -508,7 +508,7 @@ def _configure_dataloaders(tasks, group, batch_size, group_sample):
             batch_size=batch_size,
             sampler=sampler,
             num_workers=1,
-            pin_memory=True,
+            pin_memory=pin_memory,
         )
         dataloaders.append(dataloader)
 
@@ -808,10 +808,13 @@ def train(
     # Configure accelerator
     if torch.cuda.is_available():
         device_type = "cuda"
+        pin_memory = True
     elif torch.mps.is_available():
         device_type = "mps"
+        pin_memory = False
     else:
         device_type = "cpu"
+        pin_memory = False
     device = torch.device(device_type)
     logging.info("Using %s for training model %s.", device_type, run_id)
 
@@ -935,7 +938,7 @@ def train(
 
         # Get dataloaders
         train_dataloaders = _configure_dataloaders(
-            tasks, "train", batch_size, train_sample
+            tasks, "train", batch_size, train_sample, pin_memory=pin_memory
         )
 
         # Run training epoch
@@ -964,7 +967,7 @@ def train(
         if dev_ratio is not None:
             # Get dataloaders
             dev_dataloaders = _configure_dataloaders(
-                tasks, "dev", batch_size, dev_sample
+                tasks, "dev", batch_size, dev_sample, pin_memory=pin_memory
             )
 
             # Run dev epoch

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,161 @@
+import numpy as np
+import pytest
+import yaml
+from sklearn.metrics import classification_report
+
+import lisbet.evaluation as evaluation
+
+
+@pytest.fixture
+def dummy_inference(monkeypatch):
+    # Patch _process_inference_dataset to return dummy predictions
+    monkeypatch.setattr(
+        evaluation.inference,
+        "_process_inference_dataset",
+        lambda **kwargs: [
+            ("rec1", np.array([[1, 0], [0, 1], [1, 0]])),
+            ("rec2", np.array([[0, 1], [1, 0]])),
+        ],
+    )
+
+
+@pytest.fixture
+def dummy_load_records(monkeypatch):
+    # Patch load_records to return dummy ground-truth labels
+    def _dummy_load_records(*args, **kwargs):
+        return {
+            "main_records": [
+                ("rec1", {"annotations": DummyAnnotation([0, 1, 0])}),
+                ("rec2", {"annotations": DummyAnnotation([1, 0])}),
+            ]
+        }
+
+    monkeypatch.setattr(evaluation, "load_records", _dummy_load_records)
+
+
+class DummyAnnotation:
+    def __init__(self, labels):
+        self.target_cls = DummyTargetCls(labels)
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+
+class DummyTargetCls:
+    def __init__(self, labels):
+        self.labels = np.array(labels)
+
+    def argmax(self, axis):
+        return self
+
+    def squeeze(self):
+        return self
+
+    @property
+    def values(self):
+        return self.labels
+
+
+def test_evaluate_model_basic(tmp_path, dummy_inference, dummy_load_records):
+    # Prepare dummy model config file
+    model_path = tmp_path / "model_config.yml"
+    with open(model_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump({"model_id": "dummy_model"}, f)
+    weights_path = tmp_path / "weights.pt"
+    weights_path.write_bytes(b"dummy")  # Just to have a file
+
+    # Run evaluation
+    report = evaluation.evaluate_model(
+        model_path=str(model_path),
+        weights_path=str(weights_path),
+        data_format="movement",
+        data_path="dummy",
+        output_path=str(tmp_path),
+    )
+    # Should return a dict with keys like 'accuracy', 'macro avg', etc.
+    assert isinstance(report, dict)
+    assert "accuracy" in report
+
+    # Check that the YAML file was written
+    report_file = tmp_path / "evaluations" / "dummy_model" / "classification_report.yml"
+    assert report_file.exists()
+    with open(report_file, encoding="utf-8") as f:
+        loaded = yaml.safe_load(f)
+    assert loaded["accuracy"] == report["accuracy"]
+
+
+def test_evaluate_model_label_filtering(tmp_path, dummy_inference, dummy_load_records):
+    # Prepare dummy model config file
+    model_path = tmp_path / "model_config.yml"
+    with open(model_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump({"model_id": "dummy_model"}, f)
+    weights_path = tmp_path / "weights.pt"
+    weights_path.write_bytes(b"dummy")
+
+    # Only include label 0 in the report
+    report = evaluation.evaluate_model(
+        model_path=str(model_path),
+        weights_path=str(weights_path),
+        data_format="movement",
+        data_path="dummy",
+        labels="0",
+    )
+    assert isinstance(report, dict)
+    assert "0" in report
+
+
+def test_evaluate_model_f1_score_correctness(tmp_path, monkeypatch):
+    # Controlled dummy predictions and labels
+    dummy_preds = [
+        ("rec1", np.array([[1, 0], [0, 1], [1, 0]])),
+        ("rec2", np.array([[0, 1], [1, 0]])),
+    ]
+    dummy_labels = {
+        "rec1": [0, 1, 0],
+        "rec2": [1, 0],
+    }
+
+    # Patch _process_inference_dataset
+    monkeypatch.setattr(
+        evaluation.inference,
+        "_process_inference_dataset",
+        lambda **kwargs: dummy_preds,
+    )
+
+    # Patch load_records
+    def _dummy_load_records(*args, **kwargs):
+        return {
+            "main_records": [
+                ("rec1", {"annotations": DummyAnnotation(dummy_labels["rec1"])}),
+                ("rec2", {"annotations": DummyAnnotation(dummy_labels["rec2"])}),
+            ]
+        }
+
+    monkeypatch.setattr(evaluation, "load_records", _dummy_load_records)
+
+    # Prepare dummy model config file
+    model_path = tmp_path / "model_config.yml"
+    with open(model_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump({"model_id": "dummy_model"}, f)
+    weights_path = tmp_path / "weights.pt"
+    weights_path.write_bytes(b"dummy")
+
+    # Run evaluation
+    report = evaluation.evaluate_model(
+        model_path=str(model_path),
+        weights_path=str(weights_path),
+        data_format="movement",
+        data_path="dummy",
+    )
+
+    # Compute expected F1 score using sklearn
+    y_true = np.array(dummy_labels["rec1"] + dummy_labels["rec2"])
+    y_pred = np.array([0, 1, 0, 1, 0])
+    expected = classification_report(y_true, y_pred, digits=3, output_dict=True)
+
+    # Compare all relevant keys
+    for label in ["0", "1"]:
+        assert report[label]["f1-score"] == pytest.approx(expected[label]["f1-score"])
+        assert report[label]["precision"] == pytest.approx(expected[label]["precision"])
+        assert report[label]["recall"] == pytest.approx(expected[label]["recall"])
+    assert report["accuracy"] == pytest.approx(expected["accuracy"])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -124,7 +124,7 @@ def test_process_inference_dataset_input_features_incompatible(tmp_path):
             return torch.zeros((x.shape[0], 2))
 
     inference.modeling.load_model = lambda *a, **k: DummyMultiTaskModel()
-    with pytest.raises(ValueError, match="Incompatible input features!"):
+    with pytest.raises(ValueError, match="Incompatible input features"):
         inference._process_inference_dataset(
             model_path=str(config_path),
             weights_path=str(weights_path),

--- a/tests/test_input_pipeline.py
+++ b/tests/test_input_pipeline.py
@@ -73,3 +73,104 @@ class TestSwapMousePredictionDataset:
                 key, loc = dataset.window_catalog[dataset.main_indices[i]]
                 target_data = dataset._select_and_pad(key, loc)
                 npt.assert_array_equal(actual_data, target_data)
+
+
+def make_multi_individual_record(n_frames=5, n_inds=3, n_keypoints=2, n_space=2):
+    # Shape: (time, individuals, keypoints, space)
+    arr = np.arange(n_frames * n_inds * n_keypoints * n_space).reshape(
+        (n_frames, n_inds, n_keypoints, n_space)
+    )
+    ds = xr.Dataset(
+        {
+            "position": (
+                ("time", "individuals", "keypoints", "space"),
+                arr,
+            )
+        },
+        coords={
+            "time": np.arange(n_frames),
+            "individuals": [f"mouse_{i}" for i in range(n_inds)],
+            "keypoints": [f"kpt{i}" for i in range(n_keypoints)],
+            "space": ["x", "y"],
+        },
+    )
+    ds = ds.stack(features=("individuals", "keypoints", "space"))
+    return ds
+
+
+def test_base_dataset_individual_indices():
+    rec = [
+        ("rec1", {"posetracks": make_multi_individual_record(n_inds=3)}),
+    ]
+    ds = input_pipeline.BaseDataset(
+        rec, window_size=3, window_offset=0, fps_scaling=1.0, transform=None
+    )
+    assert ds.individuals == ["mouse_0", "mouse_1", "mouse_2"]
+    for ind in ds.individuals:
+        idx = ds.individual_feature_indices[ind]
+        # Each individual should have the same number of features
+        assert len(idx) == len(ds.individual_feature_indices["mouse_0"])
+
+
+def test_swap_mouse_prediction_dataset_swaps_only_second_individual():
+    rec = [
+        ("rec1", {"posetracks": make_multi_individual_record(n_inds=3)}),
+        ("rec2", {"posetracks": make_multi_individual_record(n_inds=3) + 1000}),
+    ]
+    ds = input_pipeline.SwapMousePredictionDataset(
+        rec, window_size=3, window_offset=0, fps_scaling=1.0, transform=None, seed=42
+    )
+    ds.resample_dataset()
+    for i, (actual_data, label) in enumerate(ds):
+        # Get indices for each individual
+        idxs = ds.individual_feature_indices
+        # Get the original and swapped data
+        curr_idx = ds.main_indices[i]
+        curr_key, curr_loc = ds.window_catalog[curr_idx]
+        orig_data = ds._select_and_pad(curr_key, curr_loc)
+        swap_idx = ds.extras[i]
+        swap_key, swap_loc = ds.window_catalog[swap_idx]
+        swap_data = ds._select_and_pad(swap_key, swap_loc)
+        # Only the second individual's features should be swapped if label==1
+        if label == 1:
+            # First and third individuals unchanged
+            npt.assert_array_equal(
+                actual_data[..., idxs["mouse_0"]], orig_data[..., idxs["mouse_0"]]
+            )
+            npt.assert_array_equal(
+                actual_data[..., idxs["mouse_2"]], orig_data[..., idxs["mouse_2"]]
+            )
+            # Second individual swapped
+            npt.assert_array_equal(
+                actual_data[..., idxs["mouse_1"]], swap_data[..., idxs["mouse_1"]]
+            )
+        else:
+            # All individuals unchanged
+            npt.assert_array_equal(actual_data, orig_data)
+
+
+def test_delay_mouse_prediction_dataset_shifts_only_second_individual():
+    rec = [
+        ("rec1", {"posetracks": make_multi_individual_record(n_inds=3)}),
+    ]
+    ds = input_pipeline.DelayMousePredictionDataset(
+        rec, window_size=3, window_offset=0, fps_scaling=1.0, transform=None, seed=123
+    )
+    ds.resample_dataset()
+    for i, (actual_data, _) in enumerate(ds):
+        idxs = ds.individual_feature_indices
+        curr_idx = ds.main_indices[i]
+        curr_key, curr_loc = ds.window_catalog[curr_idx]
+        orig_data = ds._select_and_pad(curr_key, curr_loc)
+        sft_loc = ds.extras[i]
+        sft_data = ds._select_and_pad(curr_key, sft_loc)
+        # Only the second individual's features should be shifted
+        npt.assert_array_equal(
+            actual_data[..., idxs["mouse_0"]], orig_data[..., idxs["mouse_0"]]
+        )
+        npt.assert_array_equal(
+            actual_data[..., idxs["mouse_2"]], orig_data[..., idxs["mouse_2"]]
+        )
+        npt.assert_array_equal(
+            actual_data[..., idxs["mouse_1"]], sft_data[..., idxs["mouse_1"]]
+        )

--- a/tests/test_training_helpers.py
+++ b/tests/test_training_helpers.py
@@ -129,7 +129,7 @@ def test_configure_dataloaders_min_samples(monkeypatch):
         },
     ]
     dataloaders = training._configure_dataloaders(
-        tasks, "train", batch_size=4, group_sample=None
+        tasks, "train", batch_size=4, group_sample=None, pin_memory=False
     )
     assert len(dataloaders) == 2
     assert isinstance(dataloaders[0], DummyDataLoader)

--- a/tests/test_training_integration.py
+++ b/tests/test_training_integration.py
@@ -8,7 +8,7 @@ import lisbet.training as training
 def test_train_integration(tmp_path):
     # Download a small sample dataset using the LISBET API
     datasets_core.fetch_dataset("SampleData", download_path=tmp_path)
-    data_path = tmp_path / "sample_keypoints"
+    data_path = tmp_path / "datasets" / "sample_keypoints"
     # Run a minimal training (1 epoch, small batch, minimal model)
     model = training.train(
         data_format="DLC",


### PR DESCRIPTION
This pull request introduces support for the MABe22 dataset and refines data preprocessing, scaling, and training configurations. Key changes include adding a new dataset, enhancing scaling logic, updating the input pipeline for feature selection, and improving test coverage.

### New Dataset Support:
* Added support for the MABe22 dataset, including its preprocessing and loading logic in a new module `src/lisbet/datasets/mabe22.py`. This includes methods to handle training and testing data, along with metadata and references.
* Updated `fetch_dataset` in `src/lisbet/datasets/core.py` to include MABe22 dataset retrieval and preprocessing logic.
* Added MABe22 to the dataset options in the CLI (`src/lisbet/cli.py`).

### Data Preprocessing and Scaling:
* Enhanced `_load_posetracks` in `src/lisbet/datasets/core.py` to support scaling based on explicit factors or the `image_size_px` attribute. This ensures more flexible and accurate coordinate normalization.
* Added `image_size_px` attribute to CalMS21 preprocessing to enable consistent scaling.

### Input Pipeline Refinements:
* Updated `__init__` in `src/lisbet/input_pipeline.py` to compute and store individual-specific feature indices for efficient feature selection.
* Modified `__getitem__` in `src/lisbet/input_pipeline.py` to apply swaps for specific individuals' features, improving clarity and precision.

### Training Configuration:
* Added a `pin_memory` parameter to `_configure_dataloaders` in `src/lisbet/training.py`, dynamically set based on the device type (e.g., CUDA, MPS, or CPU).

### Test Enhancements:
* Added tests to validate scaling logic, ensuring explicit scaling and `image_size_px` scaling produce consistent results and raise errors for invalid data.
* Improved error message validation in inference tests.