### PR TITLE
Fix TemporalOrderDataset bug and improve test coverage

### DIFF
--- a/src/lisbet/datasets.py
+++ b/src/lisbet/datasets.py
@@ -704,7 +704,7 @@ class TemporalWarpDataset(RandomWindowDataset):
 
         if not (0 < max_warp <= 100):
             raise ValueError(
-                "LISBET requires max_warp to be a positive integer between 0 and 100."
+                "LISBET requires max_warp to be a positive value between 0 and 100."
             )
         self.min_speed = max_warp / 100.0
         self.max_speed = 1.0 + max_warp / 100.0

--- a/src/lisbet/datasets.py
+++ b/src/lisbet/datasets.py
@@ -40,12 +40,11 @@ class WindowDataset(IterableDataset):
         """
         super().__init__()
 
+        # Validate input parameters
         if not records:
             raise ValueError("No records provided to the dataset.")
-        if window_size <= 1:
-            raise ValueError(
-                "window_size must be greater than 1 to avoid degenerate interpolation."
-            )
+        if any([rec.posetracks["individuals"].size < 2 for rec in records]):
+            raise ValueError("LISBET requires at least 2 individuals in each record.")
 
         self.records = records
         self.n_records = len(records)
@@ -113,7 +112,8 @@ class WindowDataset(IterableDataset):
             window_size = self.window_size
         if window_size <= 1:
             raise ValueError(
-                "window_size must be greater than 1 to avoid degenerate interpolation."
+                "LISBET requires window_size to be greater than 1 to avoid degenerate "
+                "interpolation."
             )
 
         x = self.records[curr_key].posetracks
@@ -180,9 +180,6 @@ class RandomWindowDataset(WindowDataset):
             The windows dataset from the provided records.
         """
         super().__init__(records, window_size, window_offset, fps_scaling, transform)
-
-        if self.n_frames < 1:
-            raise ValueError("No frames available for sampling in the dataset.")
 
         self.base_seed = (
             base_seed
@@ -253,11 +250,6 @@ class GroupConsistencyDataset(RandomWindowDataset):
     """
 
     def __iter__(self):
-        if self.records[0].posetracks["individuals"].size < 2:
-            raise ValueError(
-                "GroupConsistencyDataset requires at least 2 individuals in each "
-                "record."
-            )
         while True:
             # Select a random window (global frame index)
             global_idx = torch.randint(0, self.n_frames, (1,), generator=self.g).item()
@@ -516,7 +508,7 @@ class TemporalShiftDataset(RandomWindowDataset):
        trajectory may correspond to any individual in the group except the first.
     4. The label is either:
         - For regression: the normalized shift value in [0, 1], where 0 corresponds to
-          min_delay and 1 to max_delay.
+          neg. max_shift and 1 to pos. max shift.
         - For classification: 1 if the shift is positive (delta_delay > 0), 0
           otherwise.
     5. Padding may occur if the shifted window extends beyond the sequence boundaries,
@@ -532,8 +524,7 @@ class TemporalShiftDataset(RandomWindowDataset):
         window_size,
         window_offset=0,
         fps_scaling=1.0,
-        min_delay=-60,
-        max_delay=60,
+        max_shift=60,
         regression=False,
         transform=None,
         base_seed=None,
@@ -551,10 +542,8 @@ class TemporalShiftDataset(RandomWindowDataset):
             Offset for the window in frames (default is 0).
         fps_scaling : float, optional
             Scaling factor for the frames per second (default is 1.0).
-        min_delay : int, optional
-            Minimum delay in frames (default is -60).
-        max_delay : int, optional
-            Maximum delay in frames (default is 60).
+        max_shift : int, optional
+            Maximum time shift to apply, expressed in number of frames (default is 60).
         regression : bool, optional
             Whether to perform regression (default is False, which performs binary
             classification).
@@ -572,16 +561,14 @@ class TemporalShiftDataset(RandomWindowDataset):
 
         super().__init__(records, window_size, window_offset, fps_scaling, transform)
 
-        self.min_delay = min_delay
-        self.max_delay = max_delay
+        if max_shift <= 0:
+            raise ValueError("LISBET requires max_shift to be a positive integer.")
+
+        self.min_delay = -max_shift
+        self.max_delay = max_shift
         self.regression = regression
 
     def __iter__(self):
-        if self.records[0].posetracks["individuals"].size < 2:
-            raise ValueError(
-                "GroupConsistencyDataset requires at least 2 individuals in each "
-                "record."
-            )
         while True:
             # Select a random window (global frame index)
             global_idx = torch.randint(0, self.n_frames, (1,), generator=self.g).item()
@@ -659,21 +646,18 @@ class TemporalWarpDataset(RandomWindowDataset):
 
     Notes
     -----
-    1. The speed factor is sampled uniformly at random from [min_speed, max_speed] for
-       each sample.
+    1. The speed factor is sampled uniformly at random from [max_warp, 100 + max_warp]
+       for each sample.
     2. The actual window is extracted by resampling the original frames at the chosen
        speed, then interpolated to the fixed window size.
     3. For regression, the label is the normalized speed factor in [0, 1], where 0
-       corresponds to min_speed and 1 to max_speed.
-    4. For classification, the label is 1 if the speed is above the midpoint
-       ((min_speed + max_speed) / 2), and 0 otherwise.
+       corresponds to max_warp and 1 to 100 + max_warp.
+    4. For classification, the label is 1 if the speed is above 100, and 0 otherwise.
     5. Padding may occur if the resampled window extends beyond the sequence
        boundaries, but this is handled by the window extraction logic and is rare for
        typical settings.
     6. The window_offset parameter determines the temporal alignment of the window
        relative to the reference frame.
-    7. This task encourages the model to learn temporal dynamics and invariance to
-       speed changes in the input data.
     """
 
     def __init__(
@@ -682,8 +666,7 @@ class TemporalWarpDataset(RandomWindowDataset):
         window_size,
         window_offset=0,
         fps_scaling=1.0,
-        min_speed=0.5,
-        max_speed=1.5,
+        max_warp=50.0,
         regression=False,
         transform=None,
         base_seed=None,
@@ -701,10 +684,8 @@ class TemporalWarpDataset(RandomWindowDataset):
             Offset for the window in frames (default is 0).
         fps_scaling : float, optional
             Scaling factor for the frames per second (default is 1.0).
-        min_speed : float, optional
-            Minimum playback speed (default is 0.5).
-        max_speed : float, optional
-            Maximum playback speed (default is 1.5).
+        max_warp : float, optional
+            Maximum time warp to apply, expressed as a percentage (default is 50).
         regression : bool, optional
             Whether to perform regression (default is False, which performs binary
             classification).
@@ -721,8 +702,12 @@ class TemporalWarpDataset(RandomWindowDataset):
         """
         super().__init__(records, window_size, window_offset, fps_scaling, transform)
 
-        self.min_speed = min_speed
-        self.max_speed = max_speed
+        if not (0 < max_warp <= 100):
+            raise ValueError(
+                "LISBET requires max_warp to be a positive integer between 0 and 100."
+            )
+        self.min_speed = max_warp / 100.0
+        self.max_speed = 1.0 + max_warp / 100.0
         self.regression = regression
 
     def __iter__(self):
@@ -759,8 +744,7 @@ class TemporalWarpDataset(RandomWindowDataset):
 
             else:
                 # Set speed threshold as label
-                speed_threshold = (self.min_speed + self.max_speed) / 2.0
-                y = np.array(speed > speed_threshold, ndmin=1, dtype=np.float32)
+                y = np.array(speed > 1, ndmin=1, dtype=np.float32)
 
             # Add debugging information
             x.attrs["orig_coords"] = [rec_idx, frame_idx]

--- a/src/lisbet/datasets.py
+++ b/src/lisbet/datasets.py
@@ -300,8 +300,13 @@ class GroupConsistencyDataset(RandomWindowDataset):
 
             else:
                 # Don't swap
+                rec_idx_swap, frame_idx_swap, split_idx = rec_idx, frame_idx, 0  # debug
                 x = x_orig
                 y = np.array(0, ndmin=1, dtype=np.float32)
+
+            # Add debugging information
+            x.attrs["orig_coords"] = [rec_idx, frame_idx]
+            x.attrs["swap_coords"] = [rec_idx_swap, frame_idx_swap, split_idx]
 
             if self.transform:
                 x = self.transform(x)
@@ -622,6 +627,10 @@ class TemporalShiftDataset(RandomWindowDataset):
             else:
                 y = np.array(delta_delay > 0, ndmin=1, dtype=np.float32)
 
+            # Add debugging information
+            x.attrs["orig_coords"] = [rec_idx, frame_idx]
+            x.attrs["shift_coords"] = [rec_idx, frame_idx_delay, delta_delay]
+
             if self.transform:
                 x = self.transform(x)
 
@@ -752,6 +761,10 @@ class TemporalWarpDataset(RandomWindowDataset):
                 # Set speed threshold as label
                 speed_threshold = (self.min_speed + self.max_speed) / 2.0
                 y = np.array(speed > speed_threshold, ndmin=1, dtype=np.float32)
+
+            # Add debugging information
+            x.attrs["orig_coords"] = [rec_idx, frame_idx]
+            x.attrs["warp_coords"] = [rec_idx, frame_idx, speed]
 
             if self.transform:
                 x = self.transform(x)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,40 @@
-import copy
+"""
+Comprehensive tests for datasets module focusing on core logic.
+
+This test suite focuses on testing the actual logic and functionality of the dataset
+classes rather than trivial shape checks. It includes:
+
+1. **WindowDataset**: Tests core window extraction, global-to-local mapping, padding,
+   fps scaling, and input validation.
+
+2. **RandomWindowDataset**: Tests deterministic behavior with seeds and randomness
+   control using monkeypatching.
+
+3. **GroupConsistencyDataset**: Tests the group swapping logic, labeling consistency,
+   and individual mixing at random split points.
+
+4. **TemporalOrderDataset**: Tests temporal ordering logic, window concatenation,
+   and both 'simple' and 'strict' negative sampling methods.
+
+5. **TemporalShiftDataset**: Tests temporal shift detection in both classification
+   and regression modes, including boundary constraints and label computation.
+
+6. **TemporalWarpDataset**: Tests temporal warping (speed changes) in both
+   classification and regression modes, including interpolation accuracy.
+
+7. **Debug Information**: Tests that debugging information added to dataset outputs
+   contains the expected coordinate information for troubleshooting.
+
+8. **Edge Cases**: Tests boundary conditions, error handling, transform application,
+   and other hard-to-test scenarios.
+
+The tests use monkeypatching to control randomness rather than relying on multiple
+runs, ensuring deterministic and reliable test results. Mock records with known
+patterns are used to verify expected behavior rather than testing against arbitrary
+data.
+"""
+
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -13,337 +49,880 @@ from lisbet.datasets import (
     TemporalWarpDataset,
     WindowDataset,
 )
-
-# --- Fixtures and Helpers ---
+from lisbet.io import Record
 
 
 @pytest.fixture
-def simple_record():
-    """Create a simple record with deterministic values for interpolation checks."""
-    arr = np.arange(5 * 2 * 1 * 1).reshape((5, 2, 1, 1)).astype(np.float32)
-    ds = xr.Dataset(
-        {"position": (("time", "individuals", "keypoints", "space"), arr)},
+def mock_records():
+    """Create mock records with known data for testing."""
+    records = []
+
+    # Record 0: 100 frames, 2 individuals, 3 keypoints
+    positions = np.random.rand(100, 2, 3, 2) * 0.5 + 0.25  # Values in [0.25, 0.75]
+    posetracks = xr.Dataset(
+        {"position": (["time", "space", "keypoints", "individuals"], positions)},
         coords={
-            "time": np.arange(5),
-            "individuals": ["A", "B"],
-            "keypoints": ["nose"],
-            "space": ["x"],
+            "time": np.arange(100),
+            "space": ["x", "y"],
+            "keypoints": ["nose", "ear", "tail"],
+            "individuals": ["mouse1", "mouse2"],
         },
     )
 
-    class DummyAnn:
-        def __init__(self):
-            # Alternate labels 0, 1, 0, 1, ...
-            self.target_cls = xr.DataArray(
-                np.eye(2)[np.arange(5) % 2].reshape(5, 2, 1),
-                dims=("time", "behaviors", "annotators"),
+    # Mock annotations with simple pattern: behavior changes every 20 frames
+    target_cls = np.zeros((100, 4, 1), dtype=int)
+    for i in range(100):
+        behavior_idx = (i // 20) % 4
+        target_cls[i, behavior_idx, 0] = 1
+
+    annotations = xr.Dataset(
+        {"target_cls": (["time", "behaviors", "annotators"], target_cls)},
+        coords={
+            "time": np.arange(100),
+            "behaviors": ["attack", "investigation", "mount", "other"],
+            "annotators": ["annotator0"],
+        },
+    )
+
+    records.append(Record(id="record0", posetracks=posetracks, annotations=annotations))
+
+    # Record 1: 50 frames, different pattern
+    positions = np.random.rand(50, 2, 3, 2) * 0.5 + 0.25
+    posetracks = xr.Dataset(
+        {"position": (["time", "space", "keypoints", "individuals"], positions)},
+        coords={
+            "time": np.arange(50),
+            "space": ["x", "y"],
+            "keypoints": ["nose", "ear", "tail"],
+            "individuals": ["mouse1", "mouse2"],
+        },
+    )
+
+    target_cls = np.zeros((50, 4, 1), dtype=int)
+    for i in range(50):
+        behavior_idx = (i // 10) % 4
+        target_cls[i, behavior_idx, 0] = 1
+
+    annotations = xr.Dataset(
+        {"target_cls": (["time", "behaviors", "annotators"], target_cls)},
+        coords={
+            "time": np.arange(50),
+            "behaviors": ["attack", "investigation", "mount", "other"],
+            "annotators": ["annotator0"],
+        },
+    )
+
+    records.append(Record(id="record1", posetracks=posetracks, annotations=annotations))
+
+    return records
+
+
+class TestWindowDataset:
+    """Test core WindowDataset functionality."""
+
+    def test_global_to_local_mapping(self, mock_records):
+        """
+        Test that global frame indices are correctly mapped to (record, local_frame).
+        """
+        dataset = WindowDataset(mock_records, window_size=10)
+
+        # Record 0 has 100 frames, Record 1 has 50 frames
+        # Global indices 0-99 should map to record 0
+        assert dataset._global_to_local(0) == (0, 0)
+        assert dataset._global_to_local(50) == (0, 50)
+        assert dataset._global_to_local(99) == (0, 99)
+
+        # Global indices 100-149 should map to record 1
+        assert dataset._global_to_local(100) == (1, 0)
+        assert dataset._global_to_local(125) == (1, 25)
+        assert dataset._global_to_local(149) == (1, 49)
+
+    def test_window_extraction_basic(self, mock_records):
+        """Test basic window extraction without padding."""
+        dataset = WindowDataset(mock_records, window_size=5)
+
+        # Extract window from middle of record 0
+        window = dataset._select_and_pad(curr_key=0, curr_loc=10)
+
+        assert window.sizes["time"] == 5
+        assert window.sizes["space"] == 2
+        assert window.sizes["keypoints"] == 3
+        assert window.sizes["individuals"] == 2
+
+        # Time coordinates should be relative (0, 1, 2, 3, 4)
+        np.testing.assert_array_equal(window.coords["time"].values, [0, 1, 2, 3, 4])
+
+    def test_window_extraction_with_padding(self, mock_records):
+        """Test window extraction that requires padding at boundaries."""
+        dataset = WindowDataset(mock_records, window_size=10)
+
+        # Extract window at beginning (should be padded)
+        window = dataset._select_and_pad(curr_key=0, curr_loc=2)
+
+        assert window.sizes["time"] == 10
+        # The extracted data should handle padding (filled with 0s)
+
+        # Extract window at end (should be padded)
+        window = dataset._select_and_pad(curr_key=0, curr_loc=98)
+        assert window.sizes["time"] == 10
+
+    def test_fps_scaling(self, mock_records):
+        """Test that fps_scaling affects window extraction correctly."""
+        dataset = WindowDataset(mock_records, window_size=10, fps_scaling=0.5)
+
+        # With fps_scaling=0.5, should extract from fewer actual frames
+        window = dataset._select_and_pad(curr_key=0, curr_loc=20)
+        assert window.sizes["time"] == 10  # Output size unchanged
+
+    def test_validation_errors(self, mock_records):
+        """Test input validation."""
+        # Empty records
+        with pytest.raises(ValueError, match="No records provided"):
+            WindowDataset([], window_size=10)
+
+        # Window size too small
+        with pytest.raises(ValueError, match="window_size to be greater than 1"):
+            dataset = WindowDataset(mock_records, window_size=1)
+            dataset._select_and_pad(0, 10)
+
+
+class TestRandomWindowDataset:
+    """Test RandomWindowDataset randomness control."""
+
+    def test_deterministic_with_seed(self, mock_records):
+        """Test that identical seeds produce identical sequences."""
+        dataset1 = RandomWindowDataset(mock_records, window_size=5, base_seed=42)
+        dataset2 = RandomWindowDataset(mock_records, window_size=5, base_seed=42)
+
+        # Get first few samples from each dataset
+        iter1 = iter(dataset1)
+        iter2 = iter(dataset2)
+
+        for _ in range(10):
+            x1, y1 = next(iter1)
+            x2, y2 = next(iter2)
+
+            # Windows should be identical
+            xr.testing.assert_identical(x1, x2)
+            np.testing.assert_array_equal(y1, y2)
+
+    def test_different_seeds_produce_different_sequences(self, mock_records):
+        """Test that different seeds produce different sequences."""
+        dataset1 = RandomWindowDataset(mock_records, window_size=5, base_seed=42)
+        dataset2 = RandomWindowDataset(mock_records, window_size=5, base_seed=123)
+
+        iter1 = iter(dataset1)
+        iter2 = iter(dataset2)
+
+        # Check that at least some samples are different
+        differences = 0
+        for _ in range(20):
+            x1, y1 = next(iter1)
+            x2, y2 = next(iter2)
+
+            if not np.array_equal(y1, y2):
+                differences += 1
+
+        assert differences > 0, "Different seeds should produce different sequences"
+
+
+class TestGroupConsistencyDataset:
+    """Test GroupConsistencyDataset swapping logic."""
+
+    def test_consistent_group_labeling(self, mock_records):
+        """Test that consistent groups are labeled correctly."""
+        with patch("torch.rand") as mock_rand:
+            # Force consistent groups (no swapping)
+            mock_rand.return_value = torch.tensor([0.6])  # > 0.5, so no swap
+
+            dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
+
+            with patch("torch.randint") as mock_randint:
+                mock_randint.return_value = torch.tensor([25])  # Fixed frame selection
+
+                x, y = next(iter(dataset))
+
+                # Should be labeled as consistent (0)
+                assert y == 0
+
+                # Debug info should show no swap
+                assert (
+                    x.attrs["orig_coords"][0] == x.attrs["swap_coords"][0]
+                )  # Same record
+                assert x.attrs["swap_coords"][2] == 0  # split_idx = 0 (no swap)
+
+    def test_inconsistent_group_labeling(self, mock_records):
+        """Test that inconsistent groups are labeled correctly."""
+        with patch("torch.rand") as mock_rand:
+            # Force inconsistent groups (swapping)
+            mock_rand.return_value = torch.tensor([0.3])  # < 0.5, so swap
+
+            dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
+
+            with patch("torch.randint") as mock_randint:
+                # First call: select frame from record 0
+                # Second call: select frame from record 1 (different record)
+                # Third call: select split index
+                mock_randint.side_effect = [
+                    torch.tensor([25]),  # frame from record 0
+                    torch.tensor(
+                        [125]
+                    ),  # frame from record 1 (global index 125 -> record 1, frame 25)
+                    torch.tensor([1]),  # split at index 1
+                ]
+
+                x, y = next(iter(dataset))
+
+                # Should be labeled as inconsistent (1)
+                assert y == 1
+
+                # Debug info should show swap
+                assert (
+                    x.attrs["orig_coords"][0] != x.attrs["swap_coords"][0]
+                )  # Different records
+                assert x.attrs["swap_coords"][2] == 1  # split_idx = 1
+
+    def test_individual_swapping_logic(self, mock_records):
+        """Test that individuals are correctly swapped at split point."""
+        with patch("torch.rand") as mock_rand:
+            mock_rand.return_value = torch.tensor([0.3])  # Force swap
+
+            dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
+
+            with patch("torch.randint") as mock_randint:
+                mock_randint.side_effect = [
+                    torch.tensor([25]),  # orig frame
+                    torch.tensor([125]),  # swap frame
+                    torch.tensor([1]),  # split at individual 1
+                ]
+
+                x, y = next(iter(dataset))
+
+                # Should have 2 individuals (split at 1 means first individual from
+                # orig, rest from swap)
+                assert x.sizes["individuals"] == 2
+                assert y == 1
+
+
+class TestTemporalOrderDataset:
+    """Test TemporalOrderDataset ordering logic."""
+
+    def test_ordered_sequence_labeling(self, mock_records):
+        """Test that temporally ordered sequences are labeled correctly."""
+        with patch("torch.rand") as mock_rand:
+            mock_rand.return_value = torch.tensor([0.3])  # < 0.5, so positive sample
+
+            dataset = TemporalOrderDataset(
+                mock_records, window_size=10, method="strict", base_seed=42
             )
 
-        def __getitem__(self, item):
-            return getattr(self, item)
+            with patch("torch.randint") as mock_randint:
+                # Pre window at frame 30, post window at frame 35 (same record, later
+                # time)
+                mock_randint.side_effect = [
+                    torch.tensor([30]),  # pre frame
+                    torch.tensor([35]),  # post frame (later in same record)
+                ]
 
-    rec = type("Rec", (), {})()
-    rec.posetracks = ds
-    rec.annotations = DummyAnn()
-    rec.id = "rec"
-    return rec
+                x, y = next(iter(dataset))
+
+                assert y == 1  # Ordered
+                assert (
+                    x.attrs["pre_coords"][1] < x.attrs["post_coords"][1]
+                )  # Pre before post
+                assert (
+                    x.attrs["pre_coords"][0] == x.attrs["post_coords"][0]
+                )  # Same record
+
+    def test_unordered_sequence_labeling_strict(self, mock_records):
+        """Test unordered sequences in strict mode."""
+        with patch("torch.rand") as mock_rand:
+            mock_rand.return_value = torch.tensor([0.7])  # > 0.5, so negative sample
+
+            dataset = TemporalOrderDataset(
+                mock_records, window_size=10, method="strict", base_seed=42
+            )
+
+            with patch("torch.randint") as mock_randint:
+                # Pre window at frame 50, post window at frame 30 (same record, earlier
+                # time)
+                mock_randint.side_effect = [
+                    torch.tensor([50]),  # pre frame
+                    torch.tensor([30]),  # post frame (earlier in same record)
+                ]
+
+                x, y = next(iter(dataset))
+
+                assert y == 0  # Unordered
+                assert (
+                    x.attrs["pre_coords"][1] > x.attrs["post_coords"][1]
+                )  # Pre after post
+                assert (
+                    x.attrs["pre_coords"][0] == x.attrs["post_coords"][0]
+                )  # Same record
+
+    def test_window_concatenation(self, mock_records):
+        """Test that pre and post windows are correctly concatenated."""
+        dataset = TemporalOrderDataset(mock_records, window_size=10, base_seed=42)
+        x, y = next(iter(dataset))
+
+        # Should have concatenated time dimension
+        assert x.sizes["time"] == 10
+
+        # Time coordinates should be continuous
+        time_coords = x.coords["time"].values
+        assert len(time_coords) == 10
+        # Pre half should be 0-4, post half should be 5-9
+        expected_times = list(range(10))
+        np.testing.assert_array_equal(time_coords, expected_times)
+
+    def test_invalid_method_raises_error(self, mock_records):
+        """Test that invalid method parameter raises error."""
+        with pytest.raises(ValueError, match="Invalid method 'invalid'"):
+            TemporalOrderDataset(mock_records, window_size=10, method="invalid")
 
 
-@pytest.fixture
-def two_records(simple_record):
-    """Return two simple records with offset values for swap/consistency tests."""
-    rec1 = copy.deepcopy(simple_record)
-    rec2 = copy.deepcopy(simple_record)
-    rec2.posetracks["position"].values += 1000
-    rec2.id = "rec2"
-    return [rec1, rec2]
+class TestTemporalShiftDataset:
+    """Test TemporalShiftDataset shift logic."""
+
+    def test_positive_shift_classification(self, mock_records):
+        """Test classification of positive temporal shifts."""
+        dataset = TemporalShiftDataset(
+            mock_records, window_size=5, max_shift=10, regression=False, base_seed=42
+        )
+
+        with patch("torch.randint") as mock_randint:
+            # Original frame 30, shifted frame 35 (positive shift of +5)
+            mock_randint.side_effect = [
+                torch.tensor([30]),  # original frame
+                torch.tensor([35]),  # shifted frame (positive shift)
+                torch.tensor([1]),  # split index
+            ]
+
+            x, y = next(iter(dataset))
+
+            assert y == 1  # Positive shift
+            delta_shift = x.attrs["shift_coords"][2]
+            assert delta_shift > 0
+
+    def test_negative_shift_classification(self, mock_records):
+        """Test classification of negative temporal shifts."""
+        dataset = TemporalShiftDataset(
+            mock_records, window_size=5, max_shift=10, regression=False, base_seed=42
+        )
+
+        with patch("torch.randint") as mock_randint:
+            # Original frame 40, shifted frame 35 (negative shift of -5)
+            mock_randint.side_effect = [
+                torch.tensor([40]),  # original frame
+                torch.tensor([35]),  # shifted frame (negative shift)
+                torch.tensor([1]),  # split index
+            ]
+
+            x, y = next(iter(dataset))
+
+            assert y == 0  # Negative shift
+            delta_shift = x.attrs["shift_coords"][2]
+            assert delta_shift < 0
+
+    def test_regression_mode(self, mock_records):
+        """Test regression mode returns normalized shift values."""
+        dataset = TemporalShiftDataset(
+            mock_records, window_size=5, max_shift=10, regression=True, base_seed=42
+        )
+
+        with patch("torch.randint") as mock_randint:
+            # Original frame 30, shifted frame 35 (shift of +5)
+            mock_randint.side_effect = [
+                torch.tensor([30]),  # original frame
+                torch.tensor([35]),  # shifted frame
+                torch.tensor([1]),  # split index
+            ]
+
+            x, y = next(iter(dataset))
+
+            # Shift of +5 with max_shift=10 should give normalized value of 0.75
+            # Formula: (delta - min_delay) / (max_delay - min_delay) = (5 - (-10)) /
+            # (10 - (-10)) = 15/20 = 0.75
+            expected_y = (5 - (-10)) / (10 - (-10))
+            np.testing.assert_almost_equal(y, expected_y, decimal=5)
+
+    def test_shift_bounds_respected(self, mock_records):
+        """Test that shifts respect the max_shift bounds."""
+        dataset = TemporalShiftDataset(
+            mock_records, window_size=5, max_shift=5, base_seed=42
+        )
+
+        # Check multiple samples to ensure bounds are respected
+        for _ in range(20):
+            x, y = next(iter(dataset))
+            delta_shift = x.attrs["shift_coords"][2]
+            assert -5 <= delta_shift <= 5
+
+    def test_invalid_max_shift_raises_error(self, mock_records):
+        """Test that invalid max_shift parameter raises error."""
+        with pytest.raises(ValueError, match="max_shift to be a positive integer"):
+            TemporalShiftDataset(mock_records, window_size=5, max_shift=0)
 
 
-# --- WindowDataset ---
+class TestTemporalWarpDataset:
+    """Test TemporalWarpDataset warping logic."""
+
+    def test_speed_up_classification(self, mock_records):
+        """Test classification of sped up sequences."""
+        dataset = TemporalWarpDataset(
+            mock_records, window_size=10, max_warp=50, regression=False, base_seed=42
+        )
+
+        with patch("torch.rand") as mock_rand:
+            # Set relative speed to 0.8, which gives speed = 0.8 * (1.5 - 0.5) + 0.5 =
+            # 1.3 > 1
+            mock_rand.return_value = torch.tensor([0.8])
+
+            with patch("torch.randint") as mock_randint:
+                mock_randint.return_value = torch.tensor([30])  # frame selection
+
+                x, y = next(iter(dataset))
+
+                assert y == 1  # Sped up (speed > 1)
+                speed = x.attrs["warp_coords"][2]
+                assert speed > 1.0
+
+    def test_slow_down_classification(self, mock_records):
+        """Test classification of slowed down sequences."""
+        dataset = TemporalWarpDataset(
+            mock_records, window_size=10, max_warp=50, regression=False, base_seed=42
+        )
+
+        with patch("torch.rand") as mock_rand:
+            # Set relative speed to 0.2, which gives speed = 0.2 * (1.5 - 0.5) + 0.5 =
+            # 0.7 < 1
+            mock_rand.return_value = torch.tensor([0.2])
+
+            with patch("torch.randint") as mock_randint:
+                mock_randint.return_value = torch.tensor([30])  # frame selection
+
+                x, y = next(iter(dataset))
+
+                assert y == 0  # Slowed down (speed < 1)
+                speed = x.attrs["warp_coords"][2]
+                assert speed < 1.0
+
+    def test_regression_mode(self, mock_records):
+        """Test regression mode returns relative speed values."""
+        dataset = TemporalWarpDataset(
+            mock_records, window_size=10, max_warp=50, regression=True, base_seed=42
+        )
+
+        with patch("torch.rand") as mock_rand:
+            rel_speed = 0.6
+            mock_rand.return_value = torch.tensor([rel_speed])
+
+            with patch("torch.randint") as mock_randint:
+                mock_randint.return_value = torch.tensor([30])  # frame selection
+
+                x, y = next(iter(dataset))
+
+                # Should return the relative speed directly
+                np.testing.assert_almost_equal(y, rel_speed, decimal=5)
+
+    def test_window_size_preservation(self, mock_records):
+        """Test that output window size is preserved despite warping."""
+        dataset = TemporalWarpDataset(mock_records, window_size=15, base_seed=42)
+
+        for _ in range(10):
+            x, y = next(iter(dataset))
+            # Output should always have the requested window size
+            assert x.sizes["time"] == 15
+
+    def test_invalid_max_warp_raises_error(self, mock_records):
+        """Test that invalid max_warp parameter raises error."""
+        with pytest.raises(
+            ValueError, match="max_warp to be a positive integer between 0 and 100"
+        ):
+            TemporalWarpDataset(mock_records, window_size=10, max_warp=0)
+
+        with pytest.raises(
+            ValueError, match="max_warp to be a positive integer between 0 and 100"
+        ):
+            TemporalWarpDataset(mock_records, window_size=10, max_warp=150)
 
 
-def test_windowdataset_window_and_label_correctness(simple_record):
-    """Test that WindowDataset yields correct window slices and labels."""
-    ds = WindowDataset([simple_record], window_size=3)
-    it = iter(ds)
-    # First window (should be padded at start)
-    x, y = next(it)
-    expected = np.array([0, 0, 0])  # All zeros due to padding
-    np.testing.assert_array_equal(x["position"].values[:, 0, 0, 0], expected)
-    assert y == 0  # Label from annotations at frame 0
+class TestDatasetIntegration:
+    """Integration tests across different datasets."""
 
-    # Second window (should have 2 zeros, 1 real)
-    x, y = next(it)
-    expected = np.array([0, 0, 2])
-    np.testing.assert_array_equal(x["position"].values[:, 0, 0, 0], expected)
-    assert y == 1
+    def test_transform_application(self, mock_records):
+        """Test that transforms are applied correctly."""
 
-    # Third window (should have 1 zero, 2 real)
-    x, y = next(it)
-    expected = np.array([0, 2, 4])
-    np.testing.assert_array_equal(x["position"].values[:, 0, 0, 0], expected)
-    assert y == 0
-
-    # Middle window (no padding)
-    for _ in range(2):
-        x, y = next(it)
-    expected = np.array([4, 6, 8])
-    np.testing.assert_array_equal(x["position"].values[:, 0, 0, 0], expected)
-    assert y == 0
-
-
-def test_windowdataset_interpolation_values(simple_record):
-    """Test that interpolation produces correct values for non-integer fps_scaling."""
-    ds = WindowDataset([simple_record], window_size=3, fps_scaling=1.5)
-    # For frame 2, scaled_window_size = 4, so indices: -1, 0, 1, 2
-    # interp_time_coords = linspace(-1,2,3) = [-1,0.5,2]
-    # Should interpolate between padded 0 and real data
-    x = ds._select_and_pad(0, 2)
-    # At time=-1: padded 0
-    # At time=0.5: interpolate between 0 and 2 -> 1
-    # At time=2: value is 4
-    vals = x["position"].values[:, 0, 0, 0]
-    assert np.allclose(vals, [0, 1, 4])
-
-
-def test_windowdataset_transform_applied(simple_record):
-    """Test that a custom transform is applied to the window."""
-
-    class AddOne:
-        def __call__(self, x):
-            x = x.copy(deep=True)
-            x["position"].values += 1
+        def dummy_transform(x):
+            # Add a custom attribute to verify transform was applied
+            x.attrs["transformed"] = True
             return x
 
-    ds = WindowDataset([simple_record], window_size=3, transform=AddOne())
-    x, _ = next(iter(ds))
-    ds_no = WindowDataset([simple_record], window_size=3)
-    x_no, _ = next(iter(ds_no))
-    np.testing.assert_array_equal(x["position"].values, x_no["position"].values + 1)
+        dataset = WindowDataset(mock_records, window_size=5, transform=dummy_transform)
+        x, y = next(iter(dataset))
+
+        assert x.attrs.get("transformed") is True
+
+    def test_consistent_output_structure(self, mock_records):
+        """Test that all datasets produce consistent output structures."""
+        datasets = [
+            WindowDataset(mock_records, window_size=5),
+            RandomWindowDataset(mock_records, window_size=5, base_seed=42),
+            GroupConsistencyDataset(mock_records, window_size=5, base_seed=42),
+            TemporalOrderDataset(mock_records, window_size=5, base_seed=42),
+            TemporalShiftDataset(mock_records, window_size=5, base_seed=42),
+            TemporalWarpDataset(mock_records, window_size=5, base_seed=42),
+        ]
+
+        for dataset in datasets:
+            x, y = next(iter(dataset))
+
+            # All should return xarray.Dataset for x
+            assert isinstance(x, xr.Dataset)
+
+            # All should have position data variable
+            assert "position" in x.data_vars
+
+            # All should have proper dimensions
+            assert "time" in x.dims
+            assert "space" in x.dims
+            assert "keypoints" in x.dims
+            assert "individuals" in x.dims
+
+            # Label should be numeric
+            assert isinstance(y, np.ndarray)
+            assert y.dtype in [np.float32, np.int32, np.int64]
 
 
-def test_windowdataset_errors():
-    """Test error handling for WindowDataset."""
-    rec = None
-    with pytest.raises(ValueError):
-        WindowDataset([], window_size=3)
-    arr = np.zeros((2, 1, 1, 1))
-    ds = xr.Dataset(
-        {"position": (("time", "individuals", "keypoints", "space"), arr)},
-        coords={
-            "time": [0, 1],
-            "individuals": ["A"],
-            "keypoints": ["nose"],
-            "space": ["x"],
-        },
-    )
-    rec = type("Rec", (), {})()
-    rec.posetracks = ds
-    rec.annotations = None
-    with pytest.raises(ValueError):
-        WindowDataset([rec], window_size=1)
+class TestDebugInformation:
+    """Test debugging information added to dataset outputs."""
+
+    def test_group_consistency_debug_info(self, mock_records):
+        """Test that GroupConsistencyDataset adds proper debugging information."""
+        dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
+        x, y = next(iter(dataset))
+
+        # Should have debugging information
+        assert "orig_coords" in x.attrs
+        assert "swap_coords" in x.attrs
+
+        # orig_coords should be [record_idx, frame_idx]
+        orig_coords = x.attrs["orig_coords"]
+        assert len(orig_coords) == 2
+        assert isinstance(orig_coords[0], (int, np.integer))  # record index
+        assert isinstance(orig_coords[1], (int, np.integer))  # frame index
+
+        # swap_coords should be [record_idx, frame_idx, split_idx]
+        swap_coords = x.attrs["swap_coords"]
+        assert len(swap_coords) == 3
+        assert isinstance(swap_coords[0], (int, np.integer))  # record index
+        assert isinstance(swap_coords[1], (int, np.integer))  # frame index
+        assert isinstance(swap_coords[2], (int, np.integer))  # split index
+
+    def test_temporal_order_debug_info(self, mock_records):
+        """Test that TemporalOrderDataset adds proper debugging information."""
+        dataset = TemporalOrderDataset(mock_records, window_size=6, base_seed=42)
+        x, y = next(iter(dataset))
+
+        # Should have debugging information
+        assert "pre_coords" in x.attrs
+        assert "post_coords" in x.attrs
+
+        # pre_coords should be [record_idx, frame_idx]
+        pre_coords = x.attrs["pre_coords"]
+        assert len(pre_coords) == 2
+        assert isinstance(pre_coords[0], (int, np.integer))
+        assert isinstance(pre_coords[1], (int, np.integer))
+
+        # post_coords should be [record_idx, frame_idx]
+        post_coords = x.attrs["post_coords"]
+        assert len(post_coords) == 2
+        assert isinstance(post_coords[0], (int, np.integer))
+        assert isinstance(post_coords[1], (int, np.integer))
+
+    def test_temporal_shift_debug_info(self, mock_records):
+        """Test that TemporalShiftDataset adds proper debugging information."""
+        dataset = TemporalShiftDataset(mock_records, window_size=5, base_seed=42)
+        x, y = next(iter(dataset))
+
+        # Should have debugging information
+        assert "orig_coords" in x.attrs
+        assert "shift_coords" in x.attrs
+
+        # orig_coords should be [record_idx, frame_idx]
+        orig_coords = x.attrs["orig_coords"]
+        assert len(orig_coords) == 2
+        assert isinstance(orig_coords[0], (int, np.integer))
+        assert isinstance(orig_coords[1], (int, np.integer))
+
+        # shift_coords should be [record_idx, frame_idx, delta_delay]
+        shift_coords = x.attrs["shift_coords"]
+        assert len(shift_coords) == 3
+        assert isinstance(shift_coords[0], (int, np.integer))  # record index
+        assert isinstance(shift_coords[1], (int, np.integer))  # frame index
+        assert isinstance(shift_coords[2], (int, np.integer))  # delta delay
+
+    def test_temporal_warp_debug_info(self, mock_records):
+        """Test that TemporalWarpDataset adds proper debugging information."""
+        dataset = TemporalWarpDataset(mock_records, window_size=5, base_seed=42)
+        x, y = next(iter(dataset))
+
+        # Should have debugging information
+        assert "orig_coords" in x.attrs
+        assert "warp_coords" in x.attrs
+
+        # orig_coords should be [record_idx, frame_idx]
+        orig_coords = x.attrs["orig_coords"]
+        assert len(orig_coords) == 2
+        assert isinstance(orig_coords[0], (int, np.integer))
+        assert isinstance(orig_coords[1], (int, np.integer))
+
+        # warp_coords should be [record_idx, frame_idx, speed]
+        warp_coords = x.attrs["warp_coords"]
+        assert len(warp_coords) == 3
+        assert isinstance(warp_coords[0], (int, np.integer))  # record index
+        assert isinstance(warp_coords[1], (int, np.integer))  # frame index
+        assert isinstance(warp_coords[2], (float, np.floating))  # speed factor
+
+    def test_debug_info_consistency_across_iterations(self, mock_records):
+        """
+        Test that debug information is consistent and meaningful across iterations.
+        """
+        dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
+
+        # Get multiple samples to verify consistency
+        samples = []
+        iterator = iter(dataset)
+        for _ in range(10):
+            x, y = next(iterator)
+            samples.append((x.attrs["orig_coords"], x.attrs["swap_coords"], y))
+
+        # Verify that samples make sense
+        for orig_coords, swap_coords, label in samples:
+            # Record indices should be valid
+            assert 0 <= orig_coords[0] < len(mock_records)
+            assert 0 <= swap_coords[0] < len(mock_records)
+
+            # Frame indices should be within record bounds
+            assert (
+                0
+                <= orig_coords[1]
+                < mock_records[orig_coords[0]].posetracks.sizes["time"]
+            )
+            assert (
+                0
+                <= swap_coords[1]
+                < mock_records[swap_coords[0]].posetracks.sizes["time"]
+            )
+
+            # Split index should be valid (between 1 and number of individuals)
+            assert (
+                0
+                <= swap_coords[2]
+                <= mock_records[orig_coords[0]].posetracks.sizes["individuals"]
+            )
+
+            # Label consistency: if same record and split_idx=0, should be consistent
+            # (0 label)
+            if orig_coords[0] == swap_coords[0] and swap_coords[2] == 0:
+                assert label == 0  # Consistent
 
 
-# --- RandomWindowDataset ---
+class TestEdgeCasesAndBoundaryConditions:
+    """Test edge cases and boundary conditions that are harder to test."""
 
+    def test_window_dataset_single_individual_validation(self):
+        """Test that datasets reject records with fewer than 2 individuals."""
+        # Create a record with only 1 individual
+        positions = np.random.rand(50, 2, 3, 1)  # Only 1 individual
+        posetracks = xr.Dataset(
+            {"position": (["time", "space", "keypoints", "individuals"], positions)},
+            coords={
+                "time": np.arange(50),
+                "space": ["x", "y"],
+                "keypoints": ["nose", "ear", "tail"],
+                "individuals": ["mouse1"],  # Only one individual
+            },
+        )
+        record = Record(id="single_mouse", posetracks=posetracks, annotations=None)
 
-def test_randomwindowdataset_reproducibility(simple_record):
-    """Test that RandomWindowDataset yields reproducible samples with the same seed."""
-    ds1 = RandomWindowDataset([simple_record], window_size=3, base_seed=42)
-    ds2 = RandomWindowDataset([simple_record], window_size=3, base_seed=42)
-    vals1 = [next(iter(ds1))[0]["position"].values.copy() for _ in range(5)]
-    vals2 = [next(iter(ds2))[0]["position"].values.copy() for _ in range(5)]
-    for a, b in zip(vals1, vals2):
-        np.testing.assert_array_equal(a, b)
+        with pytest.raises(ValueError, match="LISBET requires at least 2 individuals"):
+            WindowDataset([record], window_size=5)
 
+    def test_temporal_order_edge_case_last_frame(self, mock_records):
+        """Test temporal order dataset behavior at sequence boundaries."""
+        dataset = TemporalOrderDataset(mock_records, window_size=4, base_seed=42)
 
-def test_randomwindowdataset_label_and_window(simple_record):
-    """Test that RandomWindowDataset yields correct label and window for known seed."""
-    ds = RandomWindowDataset([simple_record], window_size=3, base_seed=0)
-    x, y = next(iter(ds))
-    # Should be a valid window and label from the record
-    assert x["position"].shape[0] == 3
-    assert y in (0, 1)
+        # Force selection of last frame of first record
+        with patch("torch.randint") as mock_randint:
+            mock_randint.side_effect = [
+                torch.tensor([99]),  # Last frame of record 0 (0-indexed)
+                torch.tensor([99]),  # Same frame for post window
+            ]
 
+            with patch("torch.rand") as mock_rand:
+                mock_rand.return_value = torch.tensor([0.3])  # Force positive sample
 
-def test_randomwindowdataset_error():
-    """Test error handling for RandomWindowDataset."""
-    with pytest.raises(ValueError):
-        RandomWindowDataset([], window_size=3)
+                x, y = next(iter(dataset))
 
+                # Should still work and produce valid output
+                assert x.sizes["time"] == 4
+                assert y == 1  # Positive sample (post == pre is allowed)
 
-# --- GroupConsistencyDataset ---
+    def test_temporal_shift_boundary_constraints(self, mock_records):
+        """Test that temporal shift respects record boundaries."""
+        dataset = TemporalShiftDataset(
+            mock_records, window_size=5, max_shift=20, base_seed=42
+        )
 
+        # Test multiple samples to ensure shifts stay within bounds
+        for _ in range(50):
+            x, y = next(iter(dataset))
 
-def test_groupconsistencydataset_consistent(two_records):
-    """
-    Test that non-swapped samples are consistent (label 0, all individuals from same
-    record).
-    """
-    ds = GroupConsistencyDataset(two_records, window_size=3, base_seed=123)
-    # Force non-swap by monkeypatching torch.rand to always return >= 0.5
-    orig_rand = torch.rand
-    torch.rand = lambda *a, **k: torch.tensor([0.7])
-    x, y = next(iter(ds))
-    torch.rand = orig_rand
-    assert y == 0
-    # All individuals should match one of the records
-    vals = x["position"].values
-    for rec in two_records:
-        if np.allclose(vals, rec.posetracks["position"].values[:3]):
-            break
-    else:
-        raise AssertionError("Individuals do not match any record")
+            orig_coords = x.attrs["orig_coords"]
+            shift_coords = x.attrs["shift_coords"]
 
+            # Both frames should be within the same record
+            assert orig_coords[0] == shift_coords[0]
 
-def test_groupconsistencydataset_inconsistent(two_records):
-    """
-    Test that swapped samples are inconsistent (label 1, individuals split between
-    records).
-    """
-    ds = GroupConsistencyDataset(two_records, window_size=3, base_seed=123)
-    # Force swap by monkeypatching torch.rand to always return < 0.5
-    orig_rand = torch.rand
-    torch.rand = lambda *a, **k: torch.tensor([0.2])
-    x, y = next(iter(ds))
-    torch.rand = orig_rand
-    assert y == 1
-    vals = x["position"].values
-    # The two individuals should not have identical values (should come from different
-    # records or windows)
-    assert not np.allclose(vals[:, 0], vals[:, 1]), (
-        "Individuals come from the same record/frames"
-    )
+            # Both frames should be within record bounds
+            record_length = mock_records[orig_coords[0]].posetracks.sizes["time"]
+            assert 0 <= orig_coords[1] < record_length
+            assert 0 <= shift_coords[1] < record_length
 
+    def test_temporal_warp_speed_distribution(self, mock_records):
+        """Test that temporal warp produces expected speed distribution."""
+        dataset = TemporalWarpDataset(
+            mock_records, window_size=8, max_warp=50, regression=True, base_seed=42
+        )
 
-def test_groupconsistencydataset_error():
-    """Test error handling for GroupConsistencyDataset with <2 individuals."""
-    arr = np.zeros((5, 1, 1, 1))
-    ds = xr.Dataset(
-        {"position": (("time", "individuals", "keypoints", "space"), arr)},
-        coords={
-            "time": np.arange(5),
-            "individuals": ["A"],
-            "keypoints": ["nose"],
-            "space": ["x"],
-        },
-    )
-    rec = type("Rec", (), {})()
-    rec.posetracks = ds
-    rec.annotations = None
-    with pytest.raises(ValueError):
-        ds = GroupConsistencyDataset([rec], window_size=3)
-        next(iter(ds))
+        speeds = []
+        for _ in range(100):
+            x, y = next(iter(dataset))
+            speed = x.attrs["warp_coords"][2]
+            speeds.append(speed)
 
+        speeds = np.array(speeds)
 
-# --- TemporalOrderDataset ---
+        # Speeds should be within expected range [0.5, 1.5]
+        assert np.all(speeds >= 0.5)
+        assert np.all(speeds <= 1.5)
 
+        # Distribution should cover the range reasonably
+        assert np.std(speeds) > 0.1  # Some variation
+        assert np.min(speeds) < 0.7  # Some slow speeds
+        assert np.max(speeds) > 1.3  # Some fast speeds
 
-def test_temporalorderdataset_positive_and_negative(two_records):
-    """
-    Test that TemporalOrderDataset yields both positive and negative samples with
-    correct concatenation.
-    """
-    ds = TemporalOrderDataset(two_records, window_size=4, method="simple", base_seed=42)
-    found_pos = found_neg = False
-    for _ in range(20):
-        x, y = next(iter(ds))
-        assert x["position"].shape[0] == 4
-        if y == 1:
-            found_pos = True
-        elif y == 0:
-            found_neg = True
-        # Check concatenation: first half from pre, second half from post
-        split = 2
-        pre = x["position"].values[:split]
-        post = x["position"].values[split:]
-        # Can't check exact values due to randomness, but shape should match
-        assert pre.shape[0] == 2 and post.shape[0] == 2
-    assert found_pos and found_neg
+    def test_group_consistency_retry_mechanism(self, mock_records):
+        """Test that GroupConsistencyDataset retries when selecting same record."""
+        dataset = GroupConsistencyDataset(mock_records, window_size=5, base_seed=42)
 
+        with patch("torch.rand") as mock_rand:
+            mock_rand.return_value = torch.tensor([0.3])  # Force swap
 
-def test_temporalorderdataset_strict_method(two_records):
-    """Test that TemporalOrderDataset with 'strict' method yields valid samples."""
-    ds = TemporalOrderDataset(two_records, window_size=4, method="strict", base_seed=42)
-    for _ in range(10):
-        x, y = next(iter(ds))
-        assert y in (0, 1)
-        assert x["position"].shape[0] == 4
+            with patch("torch.randint") as mock_randint:
+                # First attempt: same record (should retry)
+                # Second attempt: different record (should succeed)
+                mock_randint.side_effect = [
+                    torch.tensor([25]),  # Original frame (record 0)
+                    torch.tensor([30]),  # First swap attempt (still record 0)
+                    torch.tensor([125]),  # Second swap attempt (record 1)
+                    torch.tensor([1]),  # Split index
+                ]
 
+                x, y = next(iter(dataset))
 
-def test_temporalorderdataset_error():
-    """Test error handling for TemporalOrderDataset."""
-    with pytest.raises(ValueError):
-        TemporalOrderDataset([], window_size=3)
+                # Should eventually find different record
+                assert y == 1  # Inconsistent
+                assert x.attrs["orig_coords"][0] != x.attrs["swap_coords"][0]
 
+    def test_fps_scaling_interpolation_accuracy(self, mock_records):
+        """Test that fps_scaling produces expected interpolation results."""
+        # Create dataset with fps_scaling=2.0 (double speed)
+        dataset = WindowDataset(mock_records, window_size=4, fps_scaling=2.0)
 
-# --- TemporalShiftDataset ---
+        # Extract a window where we can predict the interpolation
+        window = dataset._select_and_pad(curr_key=0, curr_loc=10)
 
+        # Should still have 4 time points after interpolation
+        assert window.sizes["time"] == 4
+        np.testing.assert_array_equal(window.coords["time"].values, [0, 1, 2, 3])
 
-def test_temporalshiftdataset_classification_and_regression(two_records):
-    """
-    Test that TemporalShiftDataset yields correct classification and regression labels.
-    """
-    ds = TemporalShiftDataset(two_records, window_size=4, regression=False)
-    for _ in range(5):
-        x, y = next(iter(ds))
-        assert y in (0, 1)
-    ds_reg = TemporalShiftDataset(two_records, window_size=4, regression=True)
-    for _ in range(5):
-        x, y = next(iter(ds_reg))
-        assert 0.0 <= y <= 1.0
+    def test_annotation_handling_without_annotations(self):
+        """Test behavior when records have no annotations."""
+        # Create records without annotations
+        positions = np.random.rand(20, 2, 3, 2)
+        posetracks = xr.Dataset(
+            {"position": (["time", "space", "keypoints", "individuals"], positions)},
+            coords={
+                "time": np.arange(20),
+                "space": ["x", "y"],
+                "keypoints": ["nose", "ear", "tail"],
+                "individuals": ["mouse1", "mouse2"],
+            },
+        )
+        record = Record(id="no_annotations", posetracks=posetracks, annotations=None)
 
+        dataset = WindowDataset([record], window_size=5)
+        x, y = next(iter(dataset))
 
-def test_temporalshiftdataset_error():
-    """Test error handling for TemporalShiftDataset with <2 individuals."""
-    arr = np.zeros((5, 1, 1, 1))
-    ds = xr.Dataset(
-        {"position": (("time", "individuals", "keypoints", "space"), arr)},
-        coords={
-            "time": np.arange(5),
-            "individuals": ["A"],
-            "keypoints": ["nose"],
-            "space": ["x"],
-        },
-    )
-    rec = type("Rec", (), {})()
-    rec.posetracks = ds
-    rec.annotations = None
-    with pytest.raises(ValueError):
-        ds = TemporalShiftDataset([rec], window_size=3)
-        next(iter(ds))
+        # Should handle missing annotations gracefully
+        assert np.isnan(y) or y is None
 
+    def test_zero_window_offset_vs_nonzero(self, mock_records):
+        """Test that window_offset affects window extraction as expected."""
+        dataset_zero = WindowDataset(mock_records, window_size=6, window_offset=0)
+        dataset_offset = WindowDataset(mock_records, window_size=6, window_offset=2)
 
-# --- TemporalWarpDataset ---
+        # Extract from same location
+        window_zero = dataset_zero._select_and_pad(curr_key=0, curr_loc=20)
+        window_offset = dataset_offset._select_and_pad(curr_key=0, curr_loc=20)
 
+        # Both should have same output size
+        assert window_zero.sizes["time"] == 6
+        assert window_offset.sizes["time"] == 6
 
-def test_temporalwarpdataset_classification_and_regression(two_records):
-    """
-    Test that TemporalWarpDataset yields correct classification and regression labels.
-    """
-    ds = TemporalWarpDataset(two_records, window_size=4, regression=False)
-    for _ in range(5):
-        x, y = next(iter(ds))
-        assert y in (0, 1)
-    ds_reg = TemporalWarpDataset(two_records, window_size=4, regression=True)
-    for _ in range(5):
-        x, y = next(iter(ds_reg))
-        assert 0.0 <= y <= 1.0
+        # But the actual data should be different due to offset
+        # (This is hard to test precisely without knowing the exact implementation,
+        # but we can at least verify the dimensions are correct)
 
+    def test_transform_preserves_debug_info(self, mock_records):
+        """Test that transforms don't interfere with debug information."""
 
-def test_temporalwarpdataset_speed_and_interpolation(simple_record):
-    ds = TemporalWarpDataset(
-        [simple_record], window_size=3, min_speed=1.0, max_speed=1.0, base_seed=42
-    )
-    x, y = next(iter(ds))
-    # Check shape
-    assert x["position"].shape[0] == 3
-    # Check values are from the correct record (should be in [0, 8])
-    vals = x["position"].values[:, 0, 0, 0]
-    assert np.all((vals >= 0) & (vals <= 8))
+        def transform_that_modifies_attrs(x):
+            # Transform that adds its own attributes
+            x.attrs["transform_applied"] = True
+            return x
 
+        dataset = GroupConsistencyDataset(
+            mock_records,
+            window_size=5,
+            transform=transform_that_modifies_attrs,
+            base_seed=42,
+        )
 
-def test_temporalwarpdataset_error():
-    """Test error handling for TemporalWarpDataset."""
-    with pytest.raises(ValueError):
-        TemporalWarpDataset([], window_size=3)
+        x, y = next(iter(dataset))
+
+        # Should have both debug info and transform info
+        assert "orig_coords" in x.attrs
+        assert "swap_coords" in x.attrs
+        assert "transform_applied" in x.attrs
+        assert x.attrs["transform_applied"] is True
+
+    def test_random_window_infinite_iteration(self, mock_records):
+        """Test that RandomWindowDataset can iterate indefinitely."""
+        dataset = RandomWindowDataset(mock_records, window_size=5, base_seed=42)
+
+        # Should be able to get many samples without exhaustion
+        iterator = iter(dataset)
+        samples = []
+        for _ in range(200):  # More than total frames
+            x, y = next(iterator)
+            samples.append((x.sizes, y.shape))
+
+        # All samples should have consistent structure
+        for sizes, y_shape in samples:
+            assert sizes["time"] == 5
+            assert sizes["individuals"] == 2
+            assert len(y_shape) >= 0  # y can be scalar or array


### PR DESCRIPTION
This pull request refactors the `lisbet/datasets.py` module to improve parameter validation, enhance debugging capabilities, and simplify dataset configuration. Key changes include stricter input validation, the addition of debugging metadata, and renaming parameters for clarity.

### Validation Improvements:
* Added stricter validation for input parameters, such as ensuring `max_shift` is positive and `max_warp` is within valid bounds.

### Debugging Enhancements:
* Introduced debugging metadata (`attrs`) to track original and transformed coordinates for datasets, including `orig_coords`, `swap_coords`, `pre_coords`, `post_coords`, `shift_coords`, and `warp_coords`.

### Parameter Simplifications:
* Replaced `min_delay`/`max_delay` with `max_shift` for time shifts and `min_speed`/`max_speed` with `max_warp` for temporal warping, simplifying configuration and improving clarity.

### Dataset Logic Adjustments:
* Consolidated redundant validation logic by moving checks (e.g., minimum number of individuals) to the dataset initialization phase to avoid duplication.

### Functional Updates:
* Adjusted window selection logic to split pre- and post-windows more cleanly and ensure proper time alignment.