### PR TITLE
Add support for DLC .h5 files in data reader

### DIFF
--- a/src/lisbet/io/core.py
+++ b/src/lisbet/io/core.py
@@ -69,7 +69,7 @@ def _load_posetracks(seq_path, data_format, data_scale, select_coords, rename_co
     # Valid filenames and their corresponding loading functions
     # TODO: Test re matching for all supported formats.
     data_readers = {
-        "DLC": (r"(?i)(DLC.*?shuffle\d+|tracking).*\.csv$", load_poses.from_dlc_file),
+        "DLC": (r"(?i)(DLC.*?shuffle\d+|tracking).*\.(csv|h5)$", load_poses.from_dlc_file),
         "SLEAP": (r"(?i)SLEAP.*\.h5$", load_poses.from_sleap_file),
         "movement": (r"(?i)tracking.*\.nc$", partial(xr.open_dataset, engine="scipy")),
     }


### PR DESCRIPTION
Hi Giuseppe!
It allows to load .h5 tracking files. I just extended the regex pattern. 
I tested compute_embeddings and annotate_behavior and it works 👍 