### PR TITLE
Add support for multiple annotation formats

### DIFF
--- a/docs/user_guide/data_preparation.rst
+++ b/docs/user_guide/data_preparation.rst
@@ -67,3 +67,81 @@ Make sure your dataset matches this specification using the selection and renami
 
 While this requirement may seem restrictive, it ensures reproducibility and reliable behavior classification.
 Future releases may provide more flexibility for custom keypoint sets and automatic mapping between conventions.
+
+
+Annotation formats
+------------------
+
+LISBET supports multiple annotation input formats through the ``annot_format``
+option. This option specifies how annotation files are read from each sequence
+directory and converted into the internal LISBET annotation representation.
+
+The default value is ``movement``, which preserves the original LISBET behavior.
+
+Supported annotation formats are:
+
+``movement``
+    The default LISBET annotation format. This option loads NetCDF annotation
+    files from each sequence directory. Annotation files are detected when their
+    file names contain ``annotations`` or ``manual_scoring`` and end with
+    ``.nc``. This format is expected to already follow the internal LISBET
+    annotation structure.
+
+``csv``
+    A generic interval-based CSV annotation format. The CSV file must contain at
+    least the following columns:
+
+    - ``behavior``
+    - ``start_time``
+    - ``end_time``
+
+    Times are expected in seconds. They are converted to frame indices using the
+    FPS information from the corresponding pose-tracking data when available.
+
+``boris``
+    A BORIS tabular CSV export format. This option supports BORIS event tables
+    in which state behaviors are represented by paired ``START`` and ``STOP``
+    rows. The required BORIS columns are:
+
+    - ``Time``
+    - ``Media file path``
+    - ``Behavior``
+    - ``Status``
+
+    The optional ``FPS`` column is used to infer the frame rate when available.
+    If no FPS information is available, LISBET falls back to the default FPS
+    used by the annotation loader.
+
+All supported annotation formats are converted internally to the LISBET
+annotation representation:
+
+.. code-block:: text
+
+    xarray.Dataset
+        Dimensions:
+            time
+            behaviors
+            annotators
+
+        Data variable:
+            target_cls(time, behaviors, annotators)
+
+For example, BORIS annotations can be used during model training with:
+
+.. code-block:: bash
+
+    betman train_model /path/to/dataset --data_format movement --annot_format boris
+
+The same option can also be used for evaluation:
+
+.. code-block:: bash
+
+    betman evaluate_model /path/to/dataset /path/to/model_config.yml /path/to/weights.pt --data_format movement --annot_format boris
+
+If ``annot_format`` is not provided, LISBET uses:
+
+.. code-block:: text
+
+    annot_format = movement
+
+This ensures backward compatibility with existing LISBET datasets and workflows.

--- a/docs/user_guide/data_preparation.rst
+++ b/docs/user_guide/data_preparation.rst
@@ -73,10 +73,16 @@ Annotation formats
 ------------------
 
 LISBET supports multiple annotation input formats through the ``annot_format``
-option. This option specifies how annotation files are read from each sequence
-directory and converted into the internal LISBET annotation representation.
-
-The default value is ``movement``, which preserves the original LISBET behavior.
+option, which determines how manual annotations are read from each sequence
+directory and converted into the internal LISBET representation. For existing
+LISBET datasets or workflows, users should normally keep the default
+``movement`` format, which expects annotations already stored in the
+LISBET/NetCDF structure. Use ``csv-events`` for simple manual annotation tables
+in which each row defines a behavior with a start and end time, and use
+``boris`` for BORIS tabular CSV exports with paired ``START`` and ``STOP``
+events. All supported formats are converted internally to the same xarray
+annotation structure, so the downstream training and evaluation workflow remains
+unchanged.
 
 Supported annotation formats are:
 
@@ -87,7 +93,7 @@ Supported annotation formats are:
     ``.nc``. This format is expected to already follow the internal LISBET
     annotation structure.
 
-``csv``
+``csv-events``
     A generic interval-based CSV annotation format. The CSV file must contain at
     least the following columns:
 

--- a/src/lisbet/cli/__init__.py
+++ b/src/lisbet/cli/__init__.py
@@ -1,5 +1,9 @@
-"""LISBET command line interface."""
-
 from lisbet.cli.main import app
 
 __all__ = ["app"]
+__docs__ = """
+LISBET CLI
+==========
+Command line interface for LISBET, a framework for behavior analysis and machine
+learning.
+"""

--- a/src/lisbet/cli/__init__.py
+++ b/src/lisbet/cli/__init__.py
@@ -1,9 +1,5 @@
+"""LISBET command line interface."""
+
 from lisbet.cli.main import app
 
 __all__ = ["app"]
-__docs__ = """
-LISBET CLI
-==========
-Command line interface for LISBET, a framework for behavior analysis and machine
-learning.
-"""

--- a/src/lisbet/cli/common.py
+++ b/src/lisbet/cli/common.py
@@ -127,14 +127,14 @@ def add_data_io_args(parser: argparse.ArgumentParser, data_help: str) -> None:
         "--annot_format",
         type=str,
         default="movement",
-        choices=["movement", "csv", "boris"],
+        choices=["movement", "csv-events", "boris"],
         help=textwrap.dedent(
             """\
             Annotation format to load.
 
             - movement: current/default LISBET annotation format using NetCDF files
               such as annotations.nc or manual_scoring.nc.
-            - csv: generic interval-based CSV annotation format with behavior,
+            - csv-events: generic interval-based CSV annotation format with behavior,
               start_time, and end_time columns.
             - boris: BORIS tabular CSV export with paired START/STOP rows.
 
@@ -152,4 +152,7 @@ def add_data_io_args(parser: argparse.ArgumentParser, data_help: str) -> None:
             For example, 'mouse001,mouse002' or 'approach'
             """
         ),
+    )
+    parser.add_argument(
+        "--output_path", type=Path, default=Path("."), help="Output path"
     )

--- a/src/lisbet/cli/common.py
+++ b/src/lisbet/cli/common.py
@@ -124,6 +124,26 @@ def add_data_io_args(parser: argparse.ArgumentParser, data_help: str) -> None:
     """Add common data input/output arguments."""
     parser.add_argument("data_path", type=str, help=data_help)
     parser.add_argument(
+        "--annot_format",
+        type=str,
+        default="movement",
+        choices=["movement", "csv", "boris"],
+        help=textwrap.dedent(
+            """\
+            Annotation format to load.
+
+            - movement: current/default LISBET annotation format using NetCDF files
+              such as annotations.nc or manual_scoring.nc.
+            - csv: generic interval-based CSV annotation format with behavior,
+              start_time, and end_time columns.
+            - boris: BORIS tabular CSV export with paired START/STOP rows.
+
+            The selected annotation format is converted internally to the LISBET
+            xarray annotation representation.
+            """
+        ),
+    )
+    parser.add_argument(
         "--data_filter",
         type=str,
         help=textwrap.dedent(
@@ -132,7 +152,4 @@ def add_data_io_args(parser: argparse.ArgumentParser, data_help: str) -> None:
             For example, 'mouse001,mouse002' or 'approach'
             """
         ),
-    )
-    parser.add_argument(
-        "--output_path", type=Path, default=Path("."), help="Output path"
     )

--- a/src/lisbet/config/schemas.py
+++ b/src/lisbet/config/schemas.py
@@ -42,6 +42,7 @@ BackboneConfig = Annotated[
 class DataConfig(BaseModel):
     data_path: str
     data_format: str = "DLC"
+    annot_format: str = "movement"
     data_scale: str | None = None
     data_filter: str | None = None
     select_coords: str | None = None

--- a/src/lisbet/evaluation.py
+++ b/src/lisbet/evaluation.py
@@ -29,6 +29,7 @@ def evaluate(
     data_path: str,
     data_scale: str | None = None,
     data_filter: str | None = None,
+    annot_format: str = "movement",
     window_size: int = 200,
     window_offset: int = 0,
     fps_scaling: float = 1.0,
@@ -94,6 +95,7 @@ def evaluate(
         data_filter=data_filter,
         select_coords=select_coords,
         rename_coords=rename_coords,
+        annot_format=annot_format,
     )
     check_feature_compatibility(config, records)
 

--- a/src/lisbet/inference/annotation.py
+++ b/src/lisbet/inference/annotation.py
@@ -37,6 +37,7 @@ def annotate_behavior(
     data_path: str,
     data_scale: str | None = None,
     data_filter: str | None = None,
+    annot_format: str = "movement",
     mode: str = "multiclass",
     threshold: float = 0.5,
     window_size: int = 200,
@@ -118,6 +119,7 @@ def annotate_behavior(
         fps_scaling=fps_scaling,
         batch_size=batch_size,
         data_filter=data_filter,
+        annot_format=annot_format,
         select_coords=select_coords,
         rename_coords=rename_coords,
     )

--- a/src/lisbet/inference/common.py
+++ b/src/lisbet/inference/common.py
@@ -223,6 +223,7 @@ def predict(
     *,
     data_scale: str | None = None,
     data_filter: str | None = None,
+    annot_format: str = "movement",
     window_size: int = 200,
     window_offset: int = 0,
     fps_scaling: float = 1.0,
@@ -289,8 +290,8 @@ def predict(
         data_scale=data_scale,
         select_coords=select_coords,
         rename_coords=rename_coords,
+        annot_format=annot_format,
     )
-
     # Input features compatibility check
     check_feature_compatibility(config, records)
 

--- a/src/lisbet/inference/common.py
+++ b/src/lisbet/inference/common.py
@@ -292,6 +292,7 @@ def predict(
         rename_coords=rename_coords,
         annot_format=annot_format,
     )
+
     # Input features compatibility check
     check_feature_compatibility(config, records)
 

--- a/src/lisbet/inference/embedding.py
+++ b/src/lisbet/inference/embedding.py
@@ -22,6 +22,7 @@ def compute_embeddings(
     data_path: str,
     data_scale: str | None = None,
     data_filter: str | None = None,
+    annot_format: str = "movement",
     window_size: int = 200,
     window_offset: int = 0,
     fps_scaling: float = 1.0,
@@ -90,6 +91,7 @@ def compute_embeddings(
         fps_scaling=fps_scaling,
         batch_size=batch_size,
         data_filter=data_filter,
+        annot_format=annot_format,
         select_coords=select_coords,
         rename_coords=rename_coords,
     )

--- a/src/lisbet/io/annotation_formats.py
+++ b/src/lisbet/io/annotation_formats.py
@@ -1,0 +1,465 @@
+"""Annotation-format loaders for LISBET supervised fine-tuning.
+
+This module loads annotations from different external formats and converts them
+to the internal LISBET annotation representation:
+
+    xarray.Dataset
+        dims: time, behaviors, annotators
+        data variable: target_cls(time, behaviors, annotators)
+
+Supported formats
+-----------------
+movement
+    Current/default LISBET annotation format. Loads NetCDF files such as
+    annotations.nc or manual_scoring.nc.
+
+csv
+    Generic interval-based CSV annotation format with at least:
+    behavior,start_time,end_time
+
+boris
+    BORIS tabular CSV export with START/STOP rows. The converter pairs START
+    and STOP rows and creates one behavioral interval per bout.
+
+Notes
+-----
+The csv and boris loaders expect annotation times in seconds and convert them
+to frame indices using fps inferred from posetracks, the BORIS FPS column, or a
+default value.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from io import StringIO
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+BORIS_EVENT_HEADER = (
+    "Time,Media file path,Total length,FPS,Subject,Behavior,"
+    "Behavioral category,Comment,Status"
+)
+
+
+def _infer_n_frames(
+    posetracks: Optional[xr.Dataset] = None,
+    intervals_df: Optional[pd.DataFrame] = None,
+    fps: float = 30,
+) -> int:
+    """Infer the number of frames from posetracks or annotation intervals."""
+    if posetracks is not None and "time" in posetracks.sizes:
+        return int(posetracks.sizes["time"])
+
+    if intervals_df is not None and len(intervals_df) > 0:
+        return int(np.ceil(intervals_df["end_time"].max() * fps))
+
+    raise ValueError(
+        "Could not infer the number of frames. Provide posetracks or valid intervals."
+    )
+
+
+def _infer_fps(
+    posetracks: Optional[xr.Dataset] = None,
+    boris_events: Optional[pd.DataFrame] = None,
+    default_fps: float = 30,
+) -> float:
+    """Infer FPS from posetracks attributes, BORIS table, or fallback."""
+    if posetracks is not None:
+        fps = posetracks.attrs.get("fps", None)
+        if fps is not None:
+            return float(fps)
+
+    if boris_events is not None and "FPS" in boris_events.columns:
+        fps_values = pd.to_numeric(boris_events["FPS"], errors="coerce").dropna()
+        if len(fps_values) > 0:
+            return float(fps_values.iloc[0])
+
+    return float(default_fps)
+
+
+def intervals_to_lisbet_xarray(
+    intervals_df: pd.DataFrame,
+    fps: float = 30,
+    n_frames: Optional[int] = None,
+    annotator: str = "annotator0",
+    behavior_col: str = "behavior",
+    start_col: str = "start_time",
+    end_col: str = "end_time",
+    other_label: str = "other",
+    add_other: bool = True,
+    source_software: str = "CSV",
+) -> xr.Dataset:
+    """Convert interval annotations to the internal LISBET xarray format.
+
+    Parameters
+    ----------
+    intervals_df
+        Interval annotation table. Required columns are behavior, start_time,
+        and end_time. Times are expected in seconds.
+    fps
+        Frames per second used to convert seconds to frame indices.
+    n_frames
+        Number of frames in the corresponding tracking sequence. If None, it is
+        inferred from the maximum end time.
+    annotator
+        Name assigned to the annotator coordinate.
+    behavior_col, start_col, end_col
+        Column names in the interval table.
+    other_label
+        Label assigned to frames without any annotated behavior.
+    add_other
+        Whether to add an "other" behavior for unannotated frames.
+    source_software
+        Stored in the output xarray Dataset attributes.
+
+    Returns
+    -------
+    xarray.Dataset
+        LISBET-compatible annotation dataset.
+    """
+    df = intervals_df.copy()
+
+    required_cols = [behavior_col, start_col, end_col]
+    missing = [col for col in required_cols if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required interval columns: {missing}")
+
+    df[start_col] = pd.to_numeric(df[start_col], errors="raise")
+    df[end_col] = pd.to_numeric(df[end_col], errors="raise")
+
+    if (df[end_col] <= df[start_col]).any():
+        bad = df.loc[df[end_col] <= df[start_col]]
+        raise ValueError(f"Invalid intervals with end_time <= start_time:\n{bad}")
+
+    df["start_frame"] = np.floor(df[start_col] * fps).astype(int)
+    df["end_frame"] = np.ceil(df[end_col] * fps).astype(int)
+
+    if n_frames is None:
+        n_frames = _infer_n_frames(intervals_df=df, fps=fps)
+
+    behaviors = sorted(df[behavior_col].astype(str).unique().tolist())
+
+    if add_other and other_label not in behaviors:
+        behaviors.append(other_label)
+
+    behavior_to_idx = {behavior: idx for idx, behavior in enumerate(behaviors)}
+    target_cls = np.zeros((n_frames, len(behaviors), 1), dtype=np.int64)
+
+    for _, row in df.iterrows():
+        behavior = str(row[behavior_col])
+        start_frame = max(int(row["start_frame"]), 0)
+        end_frame = min(int(row["end_frame"]), n_frames)
+
+        if end_frame <= start_frame:
+            continue
+
+        b_idx = behavior_to_idx[behavior]
+        target_cls[start_frame:end_frame, b_idx, 0] = 1
+
+    if add_other:
+        other_idx = behavior_to_idx[other_label]
+        active_any = target_cls[:, :, 0].sum(axis=1) > 0
+        target_cls[~active_any, other_idx, 0] = 1
+
+    return xr.Dataset(
+        data_vars={
+            "target_cls": (
+                ("time", "behaviors", "annotators"),
+                target_cls,
+            )
+        },
+        coords={
+            "time": np.arange(n_frames, dtype=np.int64),
+            "behaviors": np.array(behaviors, dtype=str),
+            "annotators": np.array([annotator], dtype=str),
+        },
+        attrs={
+            "source_software": source_software,
+            "ds_type": "annotations",
+            "fps": fps,
+            "time_unit": "frames",
+        },
+    )
+
+
+def load_movement_annotations(seq_path: Path) -> Optional[xr.Dataset]:
+    """Load the current/default LISBET movement annotation format.
+
+    This preserves the existing LISBET behavior: annotations are read from
+    NetCDF files whose names contain "manual_scoring" or "annotations".
+    """
+    rx = re.compile(r"(?i)(manual_scoring|annotations).*\.nc$")
+
+    annotations = [
+        xr.open_dataset(pth, engine="scipy")
+        for pth in seq_path.iterdir()
+        if rx.search(pth.name)
+    ]
+
+    if len(annotations) == 0:
+        return None
+
+    annotations = xr.concat(annotations, dim="annotators")
+
+    if "behaviors" in annotations.coords:
+        logging.debug("Annotations: %s", annotations.coords["behaviors"].values)
+
+    return annotations
+
+
+def load_csv_annotations(
+    seq_path: Path,
+    posetracks: Optional[xr.Dataset] = None,
+) -> Optional[xr.Dataset]:
+    """Load a generic interval-based CSV annotation format.
+
+    Expected CSV columns
+    --------------------
+    behavior,start_time,end_time
+
+    Optional columns
+    ----------------
+    annotator,subject,video_id,media_file
+
+    Times are expected in seconds.
+    """
+    rx = re.compile(r"(?i)(manual_scoring|annotations).*\.csv$")
+    csv_files = [pth for pth in seq_path.iterdir() if rx.search(pth.name)]
+
+    if len(csv_files) == 0:
+        return None
+
+    annotations = []
+
+    for idx, csv_file in enumerate(csv_files):
+        df = pd.read_csv(csv_file)
+
+        annotator = (
+            str(df["annotator"].iloc[0])
+            if "annotator" in df.columns and len(df) > 0
+            else f"annotator{idx}"
+        )
+
+        fps = _infer_fps(posetracks=posetracks, default_fps=30)
+        n_frames = _infer_n_frames(posetracks=posetracks, intervals_df=df, fps=fps)
+
+        ann = intervals_to_lisbet_xarray(
+            df,
+            fps=fps,
+            n_frames=n_frames,
+            annotator=annotator,
+            source_software="CSV",
+        )
+
+        annotations.append(ann)
+
+    if len(annotations) == 1:
+        return annotations[0]
+
+    return xr.concat(annotations, dim="annotators")
+
+
+def read_boris_csv(boris_file: Path) -> pd.DataFrame:
+    """Read a BORIS CSV export and return the clean event table.
+
+    BORIS CSV exports may contain metadata rows before the actual event table.
+    This function detects the event-table header and reads from that point.
+
+    If the file is already a clean BORIS event table, it is read directly.
+    """
+    boris_file = Path(boris_file)
+
+    with boris_file.open("r", encoding="utf-8-sig") as f:
+        text = f.read()
+
+    start = text.find(BORIS_EVENT_HEADER)
+
+    if start == -1:
+        # The file may already be a clean BORIS event table.
+        df = pd.read_csv(boris_file)
+        required_cols = {"Time", "Media file path", "Behavior", "Status"}
+
+        if required_cols.issubset(df.columns):
+            return df
+
+        raise ValueError(
+            "Could not find the BORIS event-table header and the file does not "
+            "appear to be a clean BORIS event table. Required columns are: "
+            f"{sorted(required_cols)}"
+        )
+
+    event_text = text[start:]
+    return pd.read_csv(StringIO(event_text))
+
+
+def boris_events_to_intervals(boris_events: pd.DataFrame) -> pd.DataFrame:
+    """Convert BORIS START/STOP rows to an interval annotation table."""
+    required_cols = ["Time", "Media file path", "Behavior", "Status"]
+    missing = [col for col in required_cols if col not in boris_events.columns]
+    if missing:
+        raise ValueError(f"Missing required BORIS columns: {missing}")
+
+    df = boris_events.copy()
+
+    if "Subject" not in df.columns:
+        df["Subject"] = ""
+
+    df["Time"] = pd.to_numeric(df["Time"], errors="raise")
+    df["Status"] = df["Status"].astype(str).str.strip().str.upper()
+    df["Behavior"] = df["Behavior"].astype(str).str.strip()
+
+    df = df[df["Status"].isin(["START", "STOP"])].copy()
+
+    df = df.sort_values(
+        ["Media file path", "Subject", "Behavior", "Time"]
+    ).reset_index(drop=True)
+
+    intervals = []
+    open_events = {}
+
+    for _, row in df.iterrows():
+        media_file = str(row["Media file path"])
+        subject = "" if pd.isna(row["Subject"]) else str(row["Subject"])
+        behavior = str(row["Behavior"])
+        status = str(row["Status"])
+        time = float(row["Time"])
+
+        key = (media_file, subject, behavior)
+
+        if status == "START":
+            if key in open_events:
+                raise ValueError(
+                    f"Repeated START without STOP for behavior '{behavior}' "
+                    f"in file '{media_file}' at time {time}."
+                )
+            open_events[key] = time
+
+        elif status == "STOP":
+            if key not in open_events:
+                raise ValueError(
+                    f"STOP without START for behavior '{behavior}' "
+                    f"in file '{media_file}' at time {time}."
+                )
+
+            start_time = open_events.pop(key)
+            end_time = time
+            duration = end_time - start_time
+
+            if duration <= 0:
+                raise ValueError(
+                    f"Invalid interval for behavior '{behavior}': "
+                    f"start={start_time}, end={end_time}."
+                )
+
+            intervals.append(
+                {
+                    "video_id": os.path.basename(media_file),
+                    "media_file": media_file,
+                    "subject": subject,
+                    "behavior": behavior,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "duration": duration,
+                }
+            )
+
+    if open_events:
+        raise ValueError(
+            "Some START events do not have matching STOP events: "
+            f"{open_events}"
+        )
+
+    return pd.DataFrame(intervals)
+
+
+def load_boris_annotations(
+    seq_path: Path,
+    posetracks: Optional[xr.Dataset] = None,
+) -> Optional[xr.Dataset]:
+    """Load BORIS tabular CSV annotations and convert them to LISBET format."""
+    rx = re.compile(r"(?i)(boris|manual_scoring|annotations).*\.csv$")
+    boris_files = [pth for pth in seq_path.iterdir() if rx.search(pth.name)]
+
+    if len(boris_files) == 0:
+        return None
+
+    annotations = []
+
+    for idx, boris_file in enumerate(boris_files):
+        boris_events = read_boris_csv(boris_file)
+        intervals = boris_events_to_intervals(boris_events)
+
+        fps = _infer_fps(
+            posetracks=posetracks,
+            boris_events=boris_events,
+            default_fps=30,
+        )
+
+        n_frames = _infer_n_frames(
+            posetracks=posetracks,
+            intervals_df=intervals,
+            fps=fps,
+        )
+
+        ann = intervals_to_lisbet_xarray(
+            intervals,
+            fps=fps,
+            n_frames=n_frames,
+            annotator=f"annotator{idx}",
+            source_software="BORIS",
+        )
+
+        annotations.append(ann)
+
+    if len(annotations) == 1:
+        return annotations[0]
+
+    return xr.concat(annotations, dim="annotators")
+
+
+def load_annotations(
+    seq_path: Path,
+    annot_format: str = "movement",
+    posetracks: Optional[xr.Dataset] = None,
+) -> Optional[xr.Dataset]:
+    """Load annotations from a sequence directory using the requested format.
+
+    Parameters
+    ----------
+    seq_path
+        Sequence directory.
+    annot_format
+        Annotation format to load. Supported values are:
+        "movement", "csv", and "boris".
+    posetracks
+        Pose-tracking data used to infer number of frames and FPS for CSV or
+        BORIS interval annotations.
+
+    Returns
+    -------
+    xarray.Dataset or None
+        LISBET-compatible annotation dataset, or None if no annotation file is
+        found for the requested format.
+    """
+    annot_format = str(annot_format).lower()
+
+    if annot_format == "movement":
+        return load_movement_annotations(seq_path)
+
+    if annot_format == "csv":
+        return load_csv_annotations(seq_path, posetracks=posetracks)
+
+    if annot_format == "boris":
+        return load_boris_annotations(seq_path, posetracks=posetracks)
+
+    raise ValueError(
+        f"Unsupported annot_format='{annot_format}'. "
+        "Expected one of: movement, csv, boris."
+    )

--- a/src/lisbet/io/annotation_formats.py
+++ b/src/lisbet/io/annotation_formats.py
@@ -13,8 +13,8 @@ movement
     Current/default LISBET annotation format. Loads NetCDF files such as
     annotations.nc or manual_scoring.nc.
 
-csv
-    Generic interval-based CSV annotation format with at least:
+csv-events
+    Generic interval-based CSV event annotation format with at least:
     behavior,start_time,end_time
 
 boris
@@ -23,8 +23,8 @@ boris
 
 Notes
 -----
-The csv and boris loaders expect annotation times in seconds and convert them
-to frame indices using fps inferred from posetracks, the BORIS FPS column, or a
+The csv-events and boris loaders expect annotation times in seconds and convert them
+to frame indices using the provided fps value, the BORIS FPS column, or a
 default value.
 """
 
@@ -49,32 +49,30 @@ BORIS_EVENT_HEADER = (
 
 
 def _infer_n_frames(
-    posetracks: Optional[xr.Dataset] = None,
+    n_frames: Optional[int] = None,
     intervals_df: Optional[pd.DataFrame] = None,
     fps: float = 30,
 ) -> int:
-    """Infer the number of frames from posetracks or annotation intervals."""
-    if posetracks is not None and "time" in posetracks.sizes:
-        return int(posetracks.sizes["time"])
+    """Infer the number of frames from metadata or annotation intervals."""
+    if n_frames is not None:
+        return int(n_frames)
 
     if intervals_df is not None and len(intervals_df) > 0:
         return int(np.ceil(intervals_df["end_time"].max() * fps))
 
     raise ValueError(
-        "Could not infer the number of frames. Provide posetracks or valid intervals."
+        "Could not infer the number of frames. Provide n_frames or valid intervals."
     )
 
 
 def _infer_fps(
-    posetracks: Optional[xr.Dataset] = None,
+    fps: Optional[float] = None,
     boris_events: Optional[pd.DataFrame] = None,
     default_fps: float = 30,
 ) -> float:
-    """Infer FPS from posetracks attributes, BORIS table, or fallback."""
-    if posetracks is not None:
-        fps = posetracks.attrs.get("fps", None)
-        if fps is not None:
-            return float(fps)
+    """Infer FPS from explicit metadata, BORIS table, or fallback."""
+    if fps is not None:
+        return float(fps)
 
     if boris_events is not None and "FPS" in boris_events.columns:
         fps_values = pd.to_numeric(boris_events["FPS"], errors="coerce").dropna()
@@ -214,9 +212,10 @@ def load_movement_annotations(seq_path: Path) -> Optional[xr.Dataset]:
     return annotations
 
 
-def load_csv_annotations(
+def load_csv_event_annotations(
     seq_path: Path,
-    posetracks: Optional[xr.Dataset] = None,
+    n_frames: Optional[int] = None,
+    fps: Optional[float] = None,
 ) -> Optional[xr.Dataset]:
     """Load a generic interval-based CSV annotation format.
 
@@ -247,13 +246,17 @@ def load_csv_annotations(
             else f"annotator{idx}"
         )
 
-        fps = _infer_fps(posetracks=posetracks, default_fps=30)
-        n_frames = _infer_n_frames(posetracks=posetracks, intervals_df=df, fps=fps)
+        ann_fps = _infer_fps(fps=fps, default_fps=30)
+        ann_n_frames = _infer_n_frames(
+            n_frames=n_frames,
+            intervals_df=df,
+            fps=ann_fps,
+        )
 
         ann = intervals_to_lisbet_xarray(
             df,
-            fps=fps,
-            n_frames=n_frames,
+            fps=ann_fps,
+            n_frames=ann_n_frames,
             annotator=annotator,
             source_software="CSV",
         )
@@ -381,7 +384,8 @@ def boris_events_to_intervals(boris_events: pd.DataFrame) -> pd.DataFrame:
 
 def load_boris_annotations(
     seq_path: Path,
-    posetracks: Optional[xr.Dataset] = None,
+    n_frames: Optional[int] = None,
+    fps: Optional[float] = None,
 ) -> Optional[xr.Dataset]:
     """Load BORIS tabular CSV annotations and convert them to LISBET format."""
     rx = re.compile(r"(?i)(boris|manual_scoring|annotations).*\.csv$")
@@ -396,22 +400,22 @@ def load_boris_annotations(
         boris_events = read_boris_csv(boris_file)
         intervals = boris_events_to_intervals(boris_events)
 
-        fps = _infer_fps(
-            posetracks=posetracks,
+        ann_fps = _infer_fps(
+            fps=fps,
             boris_events=boris_events,
             default_fps=30,
         )
 
-        n_frames = _infer_n_frames(
-            posetracks=posetracks,
+        ann_n_frames = _infer_n_frames(
+            n_frames=n_frames,
             intervals_df=intervals,
-            fps=fps,
+            fps=ann_fps,
         )
 
         ann = intervals_to_lisbet_xarray(
             intervals,
-            fps=fps,
-            n_frames=n_frames,
+            fps=ann_fps,
+            n_frames=ann_n_frames,
             annotator=f"annotator{idx}",
             source_software="BORIS",
         )
@@ -427,7 +431,8 @@ def load_boris_annotations(
 def load_annotations(
     seq_path: Path,
     annot_format: str = "movement",
-    posetracks: Optional[xr.Dataset] = None,
+    n_frames: Optional[int] = None,
+    fps: Optional[float] = None,
 ) -> Optional[xr.Dataset]:
     """Load annotations from a sequence directory using the requested format.
 
@@ -437,10 +442,12 @@ def load_annotations(
         Sequence directory.
     annot_format
         Annotation format to load. Supported values are:
-        "movement", "csv", and "boris".
-    posetracks
-        Pose-tracking data used to infer number of frames and FPS for CSV or
-        BORIS interval annotations.
+        "movement", "csv-events", and "boris".
+    n_frames
+        Number of frames in the corresponding pose-tracking sequence.
+    fps
+        Frames per second used to convert interval times to frame indices.
+        If missing, BORIS FPS metadata or a default value may be used.
 
     Returns
     -------
@@ -453,13 +460,13 @@ def load_annotations(
     if annot_format == "movement":
         return load_movement_annotations(seq_path)
 
-    if annot_format == "csv":
-        return load_csv_annotations(seq_path, posetracks=posetracks)
+    if annot_format == "csv-events":
+        return load_csv_event_annotations(seq_path, n_frames=n_frames, fps=fps)
 
     if annot_format == "boris":
-        return load_boris_annotations(seq_path, posetracks=posetracks)
+        return load_boris_annotations(seq_path, n_frames=n_frames, fps=fps)
 
     raise ValueError(
         f"Unsupported annot_format='{annot_format}'. "
-        "Expected one of: movement, csv, boris."
+        "Expected one of: movement, csv-events, boris."
     )

--- a/src/lisbet/io/core.py
+++ b/src/lisbet/io/core.py
@@ -19,6 +19,7 @@ from tqdm.auto import tqdm
 
 from lisbet.config.schemas import ModelConfig
 from lisbet.modeling.factory import create_model_from_config
+from lisbet.io.annotation_formats import load_annotations as _load_annotations
 
 
 @dataclass
@@ -224,36 +225,6 @@ def _load_posetracks(seq_path, data_format, data_scale, select_coords, rename_co
     return ds
 
 
-def _load_annotations(seq_path):
-    """
-    Load annotations from a sequence directory, if present.
-
-    Returns
-    -------
-    xarray.Dataset or None
-        The loaded annotations, or None if not found.
-
-    """
-    # Find all files matching the annotations regex and load them
-    rx = re.compile(r"(?i)(manual_scoring|annotations).*\.nc$")
-    annotations = [
-        xr.open_dataset(pth, engine="scipy")
-        for pth in seq_path.iterdir()
-        if rx.search(pth.name)
-    ]
-
-    # Check if any annotations were found
-    if len(annotations) == 0:
-        return None
-
-    # Merge all annotations into a single one
-    annotations = xr.concat(annotations, dim="annotators")
-
-    logging.debug("Annotations: %s", annotations.coords["behaviors"].values)
-
-    return annotations
-
-
 def load_records(
     data_format,
     data_path,
@@ -261,56 +232,112 @@ def load_records(
     data_filter=None,
     select_coords=None,
     rename_coords=None,
+    annot_format="movement",
 ):
     """
-    Load pose-tracking records from a directory, with optional filtering, coordinate
-    selection and renaming.
+    Load pose-tracking records from a directory, with optional filtering,
+    coordinate selection, coordinate renaming, and annotation-format selection.
 
     Parameters
     ----------
     data_format : {'movement', 'DLC', 'SLEAP'}
-        Dataset format to load.
+        Pose-tracking dataset format to load.
     data_path : str or Path
         Root directory containing the sequence sub-directories.
     data_scale : str, optional
-        If supplied as WIDTHxHEIGHT or WIDTHxHEIGHTxDEPTH, every input coordinate is
-        assumed to be in data units and is divided by the given scale to obtain
-        normalized coordinates in the range [0, 1]. Otherwise, the algorithm infers the
-        active extent directly from the data.
+        If supplied as WIDTHxHEIGHT or WIDTHxHEIGHTxDEPTH, every input coordinate
+        is assumed to be in data units and is divided by the given scale to obtain
+        normalized coordinates in the range [0, 1]. Otherwise, the algorithm infers
+        the active extent directly from the data.
     data_filter : str, optional
-        Comma-separated substrings; a record is kept if any substring occurs in its
-        relative path. By default, all records are kept.
-    select_coords : str or None
-        Optional subset string in the format 'INDIVIDUALS;AXES;KEYPOINTS', where each
-        field is a comma-separated list or '*' for all. If None, all data is loaded.
-        Example: 'mouse1,mouse2;x,y;nose,tail'.
-    rename_coords : str or None
-        Optional coordinate names remapping in the format 'INDIVIDUALS;AXES;KEYPOINTS',
-        where each field is a comma-separated list of maps 'old_id:new_id' or '*' for
-        no remapping at that level. If None, original dataset names are used.
-        Example: 'mouse1:resident,mouse2:intruder;*;nose:snout,tail:tailbase'.
+        Comma-separated substrings used to filter records. A record is kept if any
+        substring occurs in its relative path. By default, all records are kept.
+    select_coords : str or None, optional
+        Optional subset string in the format 'INDIVIDUALS;AXES;KEYPOINTS', where
+        each field is a comma-separated list or '*' for all. If None, all data is
+        loaded.
+
+        Example:
+            'mouse1,mouse2;x,y;nose,tail'
+
+    rename_coords : str or None, optional
+        Optional coordinate-name remapping in the format
+        'INDIVIDUALS;AXES;KEYPOINTS', where each field is a comma-separated list
+        of maps 'old_id:new_id' or '*' for no remapping at that level. If None,
+        original dataset names are used.
+
+        Example:
+            'mouse1:resident,mouse2:intruder;*;nose:snout,tail:tailbase'
+
+    annot_format : {'movement', 'csv', 'boris'}, optional
+        Annotation format to load. The default is 'movement', which preserves the
+        current LISBET behavior and loads NetCDF annotation files such as
+        annotations.nc or manual_scoring.nc.
+
+        Supported values are:
+
+        - 'movement':
+            Current/default LISBET annotation format based on NetCDF files.
+        - 'csv':
+            Generic interval-based CSV annotation format with columns such as
+            behavior, start_time, and end_time.
+        - 'boris':
+            BORIS tabular CSV export format, where state behaviors are represented
+            by paired START and STOP rows.
+
+        All supported annotation formats are converted internally to the LISBET
+        annotation representation:
+
+            xarray.Dataset with dimensions:
+                time, behaviors, annotators
+
+            and data variable:
+                target_cls(time, behaviors, annotators)
 
     Returns
     -------
     list[Record]
-        A list of Record objects, each containing id, posetracks, and optionally
-        annotations.
+        A list of Record objects. Each Record contains:
+
+        - id : str
+            Record identifier relative to data_path.
+        - posetracks : xarray.Dataset
+            Loaded and preprocessed pose-tracking data.
+        - annotations : xarray.Dataset or None
+            Loaded annotations in the internal LISBET format, or None if no
+            annotation file is found for the requested annotation format.
 
     Raises
     ------
     ValueError
-        If data_format is unsupported, or if select_coords/rename_coords are invalid.
+        If data_format is unsupported, if annot_format is unsupported, if
+        select_coords or rename_coords are invalid, or if no valid records are
+        found in the specified directory.
     NotImplementedError
-        For recognized but unimplemented formats.
+        For recognized but unimplemented pose-tracking formats.
 
     Examples
     --------
+    Load records using the default LISBET/movement annotation format:
+
     >>> records = load_records(
     ...     data_format="movement",
     ...     data_path="~/datasets/mice",
     ...     select_coords="mouse1,mouse2;x,y;nose,tail",
     ...     rename_coords="mouse1:resident,mouse2:intruder;*;nose:snout,tail:tailbase",
+    ...     annot_format="movement",
     ... )
+
+    Load records with BORIS CSV annotations:
+
+    >>> records = load_records(
+    ...     data_format="movement",
+    ...     data_path="~/datasets/mice",
+    ...     annot_format="boris",
+    ... )
+
+    Inspect the first loaded record:
+
     >>> print(len(records))
     42
     >>> print(records[0].id)
@@ -342,49 +369,67 @@ def load_records(
     for seq_path in tqdm(seq_paths, desc="Loading dataset"):
         # Load pose-tracking data
         posetracks = _load_posetracks(
-            seq_path, data_format, data_scale, select_coords, rename_coords
+            seq_path,
+            data_format,
+            data_scale,
+            select_coords,
+            rename_coords,
         )
+
         if posetracks is None:
             logging.debug("Skipping %s, no tracking data found", str(seq_path))
             continue
 
-        # Load annotations
-        annotations = _load_annotations(seq_path)
+        # Load annotations using the requested annotation format
+        annotations = _load_annotations(
+            seq_path,
+            annot_format=annot_format,
+            posetracks=posetracks,
+        )
 
         # Create record id
         rec_id = str(seq_path.relative_to(data_path))
 
         # Add Record object to the list
         records.append(
-            Record(id=rec_id, posetracks=posetracks, annotations=annotations)
+            Record(
+                id=rec_id,
+                posetracks=posetracks,
+                annotations=annotations,
+            )
         )
 
-    # Sanity check: All posetracks must have the same 'features' coordinate (summary of
-    #               individuals/keypoints/space)
+    # Sanity check: all posetracks must have the same coordinate structure
     if records:
         ref_coords = {
             dim: records[0].posetracks.coords[dim].values.tolist()
             for dim in ("individuals", "keypoints", "space")
         }
+
         for rec in records:
             for dim in ("individuals", "keypoints", "space"):
                 ds_coords = rec.posetracks.coords[dim].values.tolist()
+
                 if ds_coords != ref_coords[dim]:
                     raise ValueError(
                         f"Inconsistent posetracks coordinates in record '{rec.id}':\n"
                         f"Reference {dim}:\n{ref_coords[dim]}\n"
                         f"Record {dim}:\n{ds_coords}"
                     )
+
     else:
         raise ValueError(
             "No valid records found in the specified directory. Please check the data "
-            "path, format and filters to ensure they match the dataset structure.\n"
-            f"Current values are: \n data_path = {data_path}\n "
-            f"data_format = {data_format}\n data_filter = {data_filter}\n"
+            "path, format, filters, and annotation format to ensure they match the "
+            "dataset structure.\n"
+            f"Current values are:\n"
+            f"  data_path = {data_path}\n"
+            f"  data_format = {data_format}\n"
+            f"  data_filter = {data_filter}\n"
+            f"  annot_format = {annot_format}\n"
         )
 
     return records
-
 
 def load_multi_records(data_config):
     """Internal helper. Loads and splits records for all tasks."""
@@ -402,6 +447,8 @@ def load_multi_records(data_config):
     logging.debug(datasources)
 
     # Load records
+    # Use getattr for annot_format to preserve backward compatibility with older
+    # configuration objects that do not yet define this field.
     multi_records = [
         load_records(
             dataset,
@@ -410,6 +457,7 @@ def load_multi_records(data_config):
             data_filter=data_config.data_filter,
             select_coords=data_config.select_coords,
             rename_coords=data_config.rename_coords,
+            annot_format=getattr(data_config, "annot_format", "movement"),
         )
         for dataset, datapath in datasources
     ]

--- a/src/lisbet/io/core.py
+++ b/src/lisbet/io/core.py
@@ -269,7 +269,7 @@ def load_records(
         Example:
             'mouse1:resident,mouse2:intruder;*;nose:snout,tail:tailbase'
 
-    annot_format : {'movement', 'csv', 'boris'}, optional
+    annot_format : {'movement', 'csv-events', 'boris'}, optional
         Annotation format to load. The default is 'movement', which preserves the
         current LISBET behavior and loads NetCDF annotation files such as
         annotations.nc or manual_scoring.nc.
@@ -278,7 +278,7 @@ def load_records(
 
         - 'movement':
             Current/default LISBET annotation format based on NetCDF files.
-        - 'csv':
+        - 'csv-events':
             Generic interval-based CSV annotation format with columns such as
             behavior, start_time, and end_time.
         - 'boris':
@@ -380,11 +380,18 @@ def load_records(
             logging.debug("Skipping %s, no tracking data found", str(seq_path))
             continue
 
-        # Load annotations using the requested annotation format
+        # Load annotations using the requested annotation format.
+        # Pass only the metadata required to align interval annotations to
+        # the tracking sequence.
+        n_frames = int(posetracks.sizes["time"])
+        fps = posetracks.attrs.get("fps", None)
+        fps = float(fps) if fps is not None else None
+
         annotations = _load_annotations(
             seq_path,
             annot_format=annot_format,
-            posetracks=posetracks,
+            n_frames=n_frames,
+            fps=fps,
         )
 
         # Create record id


### PR DESCRIPTION
This PR adds support for multiple annotation input formats in LISBET.

Main changes:

* Added an `annot_format` option with supported values: `movement`, `csv`, and `boris`.
* Preserved the current default behavior with `annot_format="movement"`.
* Added a new annotation loading module: `src/lisbet/io/annotation_formats.py`.
* Added support for generic interval-based CSV annotations.
* Added support for BORIS tabular CSV exports with paired START/STOP rows.
* Converted CSV/BORIS annotations into the internal LISBET xarray representation: `target_cls(time, behaviors, annotators)`.
* Propagated `annot_format` through `DataConfig`, CLI, inference, evaluation, and record loading.
* Updated `docs/user_guide/data_preparation.rst` to document supported annotation formats and required columns.

Local tests performed:

* Syntax checks passed for all modified files.
* `git diff --check` passed.
* CLI help shows `--annot_format {movement,csv,boris}` for training and evaluation.
* `DataConfig` accepts `annot_format="boris"`.
* `load_multi_records()` successfully loads BORIS annotations and converts them to a LISBET-compatible xarray Dataset.
* Default `movement` annotation behavior remains unchanged.
